### PR TITLE
Adding isOptional support to return, output, and initializedType

### DIFF
--- a/Sources/SyntaxSparrow/Internal/Extensions/SyntaxProtocol+IsOptional.swift
+++ b/Sources/SyntaxSparrow/Internal/Extensions/SyntaxProtocol+IsOptional.swift
@@ -9,7 +9,13 @@ import Foundation
 import SwiftSyntax
 
 extension SyntaxProtocol {
-    func resolveIsOptional(viewMode: SyntaxTreeViewMode = .fixedUp) -> Bool {
+
+    /// Will asses the current `SyntaxProtocol` node without type context (i.e not `TypeSyntaxProtocol`) and perform a parent based assessment to resolve if
+    /// the node is within an `OptionalTypeSyntax`. If there is no parent `OptionalTypeSyntax` (possible in some cases) the `nextToken` will be iterated until
+    /// the parent node is exited, or an optional token found.
+    /// - Parameter viewMode: The `SyntaxTreeViewMode` to use when parsing children.
+    /// - Returns: `Bool`
+    func resolveIsSyntaxOptional(viewMode: SyntaxTreeViewMode = .fixedUp) -> Bool {
         guard self.as(OptionalTypeSyntax.self) == nil else { return true }
         guard parent?.as(OptionalTypeSyntax.self) == nil else { return true }
         // Token assessment approach

--- a/Sources/SyntaxSparrow/Internal/Extensions/TypeSyntaxProtocol+isOptional.swift
+++ b/Sources/SyntaxSparrow/Internal/Extensions/TypeSyntaxProtocol+isOptional.swift
@@ -1,0 +1,38 @@
+//
+//  File.swift
+//  
+//
+//  Created by Michael O'Brien on 16/6/2023.
+//
+
+import Foundation
+import SwiftSyntax
+
+extension TypeSyntaxProtocol {
+    
+    /// Will asses the current `TypeSyntaxProtocol` node and return `true` if it is an optional type.
+    /// - Parameter viewMode: The `SyntaxTreeViewMode` to use when parsing children.
+    /// - Returns: `Bool`
+    func resolveIsTypeOptional(viewMode: SyntaxTreeViewMode = .fixedUp) -> Bool {
+        let softCheck = parent?.description.trimmed.hasSuffix("?") ?? false
+        guard !softCheck else { return true }
+        // Token assessment approach
+        var result = false
+        var nextToken = nextToken(viewMode: .fixedUp)
+        var potentialOptional: Bool = nextToken?.text == "?"
+        while nextToken != nil {
+            if nextToken?.text == ")" {
+                potentialOptional = true
+            }
+            if potentialOptional, nextToken?.text == ")" {
+                break
+            }
+            if potentialOptional, nextToken?.text == "?" {
+                result = true
+                break
+            }
+            nextToken = nextToken?.nextToken(viewMode: .fixedUp)
+        }
+        return result
+    }
+}

--- a/Sources/SyntaxSparrow/Internal/Resolvers/Declaration/FunctionSemanticsResolver.swift
+++ b/Sources/SyntaxSparrow/Internal/Resolvers/Declaration/FunctionSemanticsResolver.swift
@@ -61,14 +61,17 @@ struct FunctionSemanticsResolver: SemanticsResolving {
     func resolveSignature() -> Function.Signature {
         let inputParameters = node.signature.input.parameterList.map(Parameter.init)
         var outputType: EntityType?
+        var isOutputOptional: Bool = false
         if let output = node.signature.output {
             outputType = EntityType.parseType(output.returnType)
+            isOutputOptional = output.returnType.resolveIsTypeOptional()
         }
         let throwsKeyword = node.signature.effectSpecifiers?.throwsSpecifier?.text.trimmed
         let asyncKeyword = node.signature.effectSpecifiers?.asyncSpecifier?.text.trimmed
         return Function.Signature(
             input: inputParameters,
             output: outputType,
+            outputIsOptional: isOutputOptional,
             throwsOrRethrowsKeyword: throwsKeyword,
             asyncKeyword: asyncKeyword
         )

--- a/Sources/SyntaxSparrow/Internal/Resolvers/Declaration/SubscriptSemanticsResolver.swift
+++ b/Sources/SyntaxSparrow/Internal/Resolvers/Declaration/SubscriptSemanticsResolver.swift
@@ -58,6 +58,10 @@ struct SubscriptSemanticsResolver: SemanticsResolving {
         EntityType.parseType(node.result.returnType)
     }
 
+    func resolveReturnTypeIsOptional() -> Bool {
+        node.result.returnType.resolveIsTypeOptional()
+    }
+
     func resolveAccessors() -> [Accessor] {
         guard let accessor = node.accessor?.as(AccessorBlockSyntax.self) else { return [] }
         return accessor.accessors.map(Accessor.init)

--- a/Sources/SyntaxSparrow/Internal/Resolvers/Declaration/TypealiasSemanticsResolver.swift
+++ b/Sources/SyntaxSparrow/Internal/Resolvers/Declaration/TypealiasSemanticsResolver.swift
@@ -48,6 +48,10 @@ struct TypealiasSemanticsResolver: SemanticsResolving {
         EntityType.parseType(node.initializer.value)
     }
 
+    func resolveInitializedTypeIsOptional() -> Bool {
+        node.initializer.value.resolveIsTypeOptional()
+    }
+
     func resolveGenericParameters() -> [GenericParameter] {
         let parameters = GenericParameter.fromParameterList(from: node.genericParameterClause?.genericParameterList)
         return parameters

--- a/Sources/SyntaxSparrow/Internal/Resolvers/Declaration/VariableSemanticsResolver.swift
+++ b/Sources/SyntaxSparrow/Internal/Resolvers/Declaration/VariableSemanticsResolver.swift
@@ -71,7 +71,7 @@ struct VariableSemanticsResolver: SemanticsResolving {
 
     func resolveIsOptional() -> Bool {
         guard let typeNode = node.typeAnnotation else { return false }
-        return typeNode.type.resolveIsOptional()
+        return typeNode.type.resolveIsSyntaxOptional()
     }
 
     func resolveHasSetter() -> Bool {

--- a/Sources/SyntaxSparrow/Internal/Resolvers/Syntax/ClosureSemanticsResolver.swift
+++ b/Sources/SyntaxSparrow/Internal/Resolvers/Syntax/ClosureSemanticsResolver.swift
@@ -71,7 +71,7 @@ struct ClosureSemanticsResolver: SemanticsResolving {
             }
         }
         guard let parentNode = parentParameter else { return false }
-        return parentNode.resolveIsOptional(viewMode: .fixedUp)
+        return parentNode.resolveIsSyntaxOptional(viewMode: .fixedUp)
     }
 
     func resolveIsEscaping() -> Bool {

--- a/Sources/SyntaxSparrow/Internal/Resolvers/Syntax/EnumCaseParameterSemanticsResolver.swift
+++ b/Sources/SyntaxSparrow/Internal/Resolvers/Syntax/EnumCaseParameterSemanticsResolver.swift
@@ -67,7 +67,7 @@ struct EnumCaseParameterSemanticsResolver: ParameterNodeSemanticsResolving {
     }
 
     func resolveIsOptional() -> Bool {
-        return node.type.resolveIsOptional()
+        return node.type.resolveIsSyntaxOptional()
     }
 
     func resolveDefaultArgument() -> String? {

--- a/Sources/SyntaxSparrow/Internal/Resolvers/Syntax/FunctionParameterSemanticsResolver.swift
+++ b/Sources/SyntaxSparrow/Internal/Resolvers/Syntax/FunctionParameterSemanticsResolver.swift
@@ -60,7 +60,7 @@ struct FunctionParameterSemanticsResolver: ParameterNodeSemanticsResolving {
     }
 
     func resolveIsOptional() -> Bool {
-        node.type.resolveIsOptional()
+        node.type.resolveIsSyntaxOptional()
     }
 
     func resolveDefaultArgument() -> String? {

--- a/Sources/SyntaxSparrow/Internal/Resolvers/Syntax/ResultSemanticsResolver.swift
+++ b/Sources/SyntaxSparrow/Internal/Resolvers/Syntax/ResultSemanticsResolver.swift
@@ -29,7 +29,7 @@ struct ResultSemanticsResolver: SemanticsResolving {
     // MARK: - Resolvers
 
     func resolveIsOptional() -> Bool {
-        node.resolveIsOptional(viewMode: .fixedUp)
+        node.resolveIsSyntaxOptional(viewMode: .fixedUp)
     }
 
     func resolveSuccessType() -> EntityType {

--- a/Sources/SyntaxSparrow/Internal/Resolvers/Syntax/TupleElementListSemanticsResolver.swift
+++ b/Sources/SyntaxSparrow/Internal/Resolvers/Syntax/TupleElementListSemanticsResolver.swift
@@ -36,6 +36,6 @@ struct TupleElementListSemanticsResolver: TupleNodeSemanticsResolving {
     }
 
     func resolveIsOptional() -> Bool {
-        node.resolveIsOptional(viewMode: .fixedUp)
+        node.resolveIsSyntaxOptional(viewMode: .fixedUp)
     }
 }

--- a/Sources/SyntaxSparrow/Internal/Resolvers/Syntax/TupleParameterSemanticsResolver.swift
+++ b/Sources/SyntaxSparrow/Internal/Resolvers/Syntax/TupleParameterSemanticsResolver.swift
@@ -64,7 +64,7 @@ struct TupleParameterSemanticsResolver: ParameterNodeSemanticsResolving {
     }
 
     func resolveIsOptional() -> Bool {
-        node.resolveIsOptional(viewMode: .fixedUp)
+        node.resolveIsSyntaxOptional(viewMode: .fixedUp)
     }
 
     func resolveIsInOut() -> Bool {

--- a/Sources/SyntaxSparrow/Internal/Resolvers/Syntax/TupleSemanticsResolver.swift
+++ b/Sources/SyntaxSparrow/Internal/Resolvers/Syntax/TupleSemanticsResolver.swift
@@ -36,6 +36,6 @@ struct TupleSemanticsResolver: TupleNodeSemanticsResolving {
     }
 
     func resolveIsOptional() -> Bool {
-        node.resolveIsOptional(viewMode: .fixedUp)
+        node.resolveIsSyntaxOptional(viewMode: .fixedUp)
     }
 }

--- a/Sources/SyntaxSparrow/Public/Semantics/Declarations/Function.swift
+++ b/Sources/SyntaxSparrow/Public/Semantics/Declarations/Function.swift
@@ -34,6 +34,19 @@ public struct Function: Declaration, SyntaxChildCollecting {
         /// The function output type, if any.
         /// This is the return type of the function.
         public let output: EntityType?
+        
+        /// Bool indicating whether the resolved `output` property is optional.
+        ///
+        /// For example:
+        /// ```swift
+        /// func executeOrder() -> String?
+        /// func executeOtherOrder() -> String
+        /// ```
+        /// - The `executeOrder` `output` is `.simple("String?")` and `outputIsOptional` is `true`
+        /// - The `executeOtherOrder` `output` is `.simple("String")` and `outputIsOptional` is `false`
+        ///
+        /// **Note:** Value will be `false` when the `output` is `nil`
+        public let outputIsOptional: Bool
 
         /// The `throws` or `rethrows` keyword, if any.
         /// Indicates whether the function can throw an error.

--- a/Sources/SyntaxSparrow/Public/Semantics/Declarations/Subscript.swift
+++ b/Sources/SyntaxSparrow/Public/Semantics/Declarations/Subscript.swift
@@ -67,6 +67,17 @@ public struct Subscript: Declaration {
     /// The return type of the subscript.
     public var returnType: EntityType { resolver.resolveReturnType() }
 
+    /// Bool indicating whether the resolved `returnType` property is optional.
+    ///
+    /// For example:
+    /// ```swift
+    /// subscript(key: Int) -> String?
+    /// subscript(key: Int) -> String
+    /// ```
+    /// - The first subscript `returnType` is `.simple("String?")` and `returnTypeIsOptional` is `true`
+    /// - The first subscript `returnType` is `.simple("String")` and `returnTypeIsOptional` is `false`
+    public var returnTypeIsOptional: Bool { resolver.resolveReturnTypeIsOptional() }
+
     /// The subscript getter and/or setter.
     public var accessors: [Accessor] { resolver.resolveAccessors() }
 

--- a/Sources/SyntaxSparrow/Public/Semantics/Declarations/Typealias.swift
+++ b/Sources/SyntaxSparrow/Public/Semantics/Declarations/Typealias.swift
@@ -63,6 +63,17 @@ public struct Typealias: Declaration {
     /// - The third declaration has no initialized type of `.tuple(Tuple)`
     public var initializedType: EntityType { resolver.resolveInitializedType() }
 
+    /// Bool indicating whether the resolved `initializedType` property is optional.
+    ///
+    /// For example:
+    /// ```swift
+    /// typealias StringAlias = String?
+    /// typealias IntAlias = Int
+    /// ```
+    /// - The `StringAlias` `initializedType` is `.simple("String?")` and `initializedTypeIsOptional` is `true`
+    /// - The `IntAlias` `initializedType` is `.simple("Int")` and `initializedTypeIsOptional` is `false`
+    public var initializedTypeIsOptional: Bool { resolver.resolveInitializedTypeIsOptional() }
+
     /// Array of generic parameters found in the declaration.
     ///
     /// For example, in the following declaration, there is a single parameter whose `name` is `"T"` and `type` of `"Equatable"`

--- a/Tests/SyntaxSparrowTests/Declarations/FunctionTests.swift
+++ b/Tests/SyntaxSparrowTests/Declarations/FunctionTests.swift
@@ -279,6 +279,18 @@ final class FunctionTests: XCTestCase {
         XCTAssertEqual(function.genericRequirements[1].rightTypeIdentifier, "C2.Element")
     }
 
+    func test_thing() {
+        let source = #"""
+        func variadicOptional(_ names: String?...) {}
+        """#
+        instanceUnderTest.updateToSource(source)
+        XCTAssertTrue(instanceUnderTest.isStale)
+        instanceUnderTest.collectChildren()
+        XCTAssertFalse(instanceUnderTest.isStale)
+        XCTAssertEqual(instanceUnderTest.functions.count, 1)
+        XCTAssertTrue(instanceUnderTest.functions[0].signature.input[0].isOptional)
+    }
+
     func test_function_parameters_willResolveExptectedTypes() throws {
         let source = #"""
         func noParameters() throws {}
@@ -799,6 +811,28 @@ final class FunctionTests: XCTestCase {
         XCTAssertEqual(function.signature.asyncKeyword, "async")
         XCTAssertEqual(function.signature.output, .simple("String"))
         XCTAssertEqual(function.signature.input.count, 0)
+    }
+
+    func test_function_outputIsOptional_willResolveExptectedTypes() throws {
+        let source = #"""
+        func returnTypeNotOptional() -> String {}
+        func returnTypeIsOptional() -> String? {}
+        func returnTypeNotOptional() -> (() -> Void) {}
+        func returnTypeIsOptional() -> (() -> Void)? {}
+        func returnTypeNotOptional() -> (name: String, age: Int?) {}
+        func returnTypeIsOptional() -> (name: String, age: Int?)? {}
+        """#
+        instanceUnderTest.updateToSource(source)
+        XCTAssertTrue(instanceUnderTest.isStale)
+        instanceUnderTest.collectChildren()
+        XCTAssertFalse(instanceUnderTest.isStale)
+        XCTAssertEqual(instanceUnderTest.functions.count, 6)
+        XCTAssertFalse(instanceUnderTest.functions[0].signature.outputIsOptional)
+        XCTAssertTrue(instanceUnderTest.functions[1].signature.outputIsOptional)
+        XCTAssertFalse(instanceUnderTest.functions[2].signature.outputIsOptional)
+        XCTAssertTrue(instanceUnderTest.functions[3].signature.outputIsOptional)
+        XCTAssertFalse(instanceUnderTest.functions[4].signature.outputIsOptional)
+        XCTAssertTrue(instanceUnderTest.functions[5].signature.outputIsOptional)
     }
 
     func test_function_body_willResolveExpectedResult() throws {

--- a/Tests/SyntaxSparrowTests/Declarations/SubscriptTests.swift
+++ b/Tests/SyntaxSparrowTests/Declarations/SubscriptTests.swift
@@ -158,6 +158,28 @@ final class SubscriptTests: XCTestCase {
         XCTAssertEqual(instanceUnderTest.subscripts[2].accessors.map(\.kind?.rawValue), ["get", "set"])
     }
 
+    func test_subscript_returnTypeIsOptional_willResolveExpectedValues() {
+        let source = #"""
+        subscript(index: Int) -> Int { 0 }
+        subscript(index: Int) -> Int? { 0 }
+        subscript(index: Int) -> (() -> Void) { 0 }
+        subscript(index: Int) -> (() -> Void)? { 0 }
+        subscript(index: Int) -> (name: String, age: Int?) { 0 }
+        subscript(index: Int) -> (name: String, age: Int?)? { 0 }
+        """#
+        instanceUnderTest.updateToSource(source)
+        XCTAssertTrue(instanceUnderTest.isStale)
+        instanceUnderTest.collectChildren()
+        XCTAssertFalse(instanceUnderTest.isStale)
+        XCTAssertEqual(instanceUnderTest.subscripts.count, 6)
+        XCTAssertFalse(instanceUnderTest.subscripts[0].returnTypeIsOptional)
+        XCTAssertTrue(instanceUnderTest.subscripts[1].returnTypeIsOptional)
+        XCTAssertFalse(instanceUnderTest.subscripts[2].returnTypeIsOptional)
+        XCTAssertTrue(instanceUnderTest.subscripts[3].returnTypeIsOptional)
+        XCTAssertFalse(instanceUnderTest.subscripts[4].returnTypeIsOptional)
+        XCTAssertTrue(instanceUnderTest.subscripts[5].returnTypeIsOptional)
+    }
+
     func test_subscript_indicies_willResolveExpectedValues() throws {
         let source = #"""
         subscript(_ index: Int) -> Int {}

--- a/Tests/SyntaxSparrowTests/Declarations/TypealiasTests.swift
+++ b/Tests/SyntaxSparrowTests/Declarations/TypealiasTests.swift
@@ -165,6 +165,28 @@ final class TypealiasTests: XCTestCase {
         XCTAssertEqual(typealiasDecl.description, "public typealias MyCustomType = Int?")
     }
 
+    func test_typealias_initializedTypeIsOptional_willResolveExpectedValues() {
+        let source = #"""
+        typealias MyAlias = String
+        typealias MyAlias = String?
+        typealias MyAlias = (() -> Void)
+        typealias MyAlias = (() -> Void)?
+        typealias MyAlias = (name: String, age: Int?)
+        typealias MyAlias = (name: String, age: Int?)?
+        """#
+        instanceUnderTest.updateToSource(source)
+        XCTAssertTrue(instanceUnderTest.isStale)
+        instanceUnderTest.collectChildren()
+        XCTAssertFalse(instanceUnderTest.isStale)
+        XCTAssertEqual(instanceUnderTest.typealiases.count, 6)
+        XCTAssertFalse(instanceUnderTest.typealiases[0].initializedTypeIsOptional)
+        XCTAssertTrue(instanceUnderTest.typealiases[1].initializedTypeIsOptional)
+        XCTAssertFalse(instanceUnderTest.typealiases[2].initializedTypeIsOptional)
+        XCTAssertTrue(instanceUnderTest.typealiases[3].initializedTypeIsOptional)
+        XCTAssertFalse(instanceUnderTest.typealiases[4].initializedTypeIsOptional)
+        XCTAssertTrue(instanceUnderTest.typealiases[5].initializedTypeIsOptional)
+    }
+
     func test_hashable_equatable_willReturnExpectedResults() throws {
         let source = #"""
         typealias MyCustomType = Int


### PR DESCRIPTION
- Adds bool `isOptional` check for Function output, typealias initializedType, and subscript returnType