### PR TITLE
Adding recursive collection conveniences and exposing EntityType init

### DIFF
--- a/Sources/SyntaxSparrow/Internal/Resolvers/Declaration/DeinitializerSemanticsResolver.swift
+++ b/Sources/SyntaxSparrow/Internal/Resolvers/Declaration/DeinitializerSemanticsResolver.swift
@@ -39,4 +39,9 @@ struct DeinitializerSemanticsResolver: SemanticsResolving {
         guard let modifierList = node.modifiers else { return [] }
         return modifierList.map { Modifier(node: $0) }
     }
+
+    func resolveBody() -> CodeBlock? {
+        guard let body = node.body else { return nil }
+        return CodeBlock(node: body)
+    }
 }

--- a/Sources/SyntaxSparrow/Internal/Resolvers/Declaration/FunctionSemanticsResolver.swift
+++ b/Sources/SyntaxSparrow/Internal/Resolvers/Declaration/FunctionSemanticsResolver.swift
@@ -63,7 +63,7 @@ struct FunctionSemanticsResolver: SemanticsResolving {
         var outputType: EntityType?
         var isOutputOptional: Bool = false
         if let output = node.signature.output {
-            outputType = EntityType.parseType(output.returnType)
+            outputType = EntityType(output.returnType)
             isOutputOptional = output.returnType.resolveIsTypeOptional()
         }
 

--- a/Sources/SyntaxSparrow/Internal/Resolvers/Declaration/InitializerSemanticsResolver.swift
+++ b/Sources/SyntaxSparrow/Internal/Resolvers/Declaration/InitializerSemanticsResolver.swift
@@ -66,4 +66,9 @@ struct InitializerSemanticsResolver: SemanticsResolving {
         guard let specifiers = node.signature.effectSpecifiers else { return nil }
         return EffectSpecifiers(node: specifiers)
     }
+
+    func resolveBody() -> CodeBlock? {
+        guard let body = node.body else { return nil }
+        return CodeBlock(node: body)
+    }
 }

--- a/Sources/SyntaxSparrow/Internal/Resolvers/Declaration/SubscriptSemanticsResolver.swift
+++ b/Sources/SyntaxSparrow/Internal/Resolvers/Declaration/SubscriptSemanticsResolver.swift
@@ -55,7 +55,7 @@ struct SubscriptSemanticsResolver: SemanticsResolving {
     }
 
     func resolveReturnType() -> EntityType {
-        EntityType.parseType(node.result.returnType)
+        EntityType(node.result.returnType)
     }
 
     func resolveReturnTypeIsOptional() -> Bool {

--- a/Sources/SyntaxSparrow/Internal/Resolvers/Declaration/TypealiasSemanticsResolver.swift
+++ b/Sources/SyntaxSparrow/Internal/Resolvers/Declaration/TypealiasSemanticsResolver.swift
@@ -45,7 +45,7 @@ struct TypealiasSemanticsResolver: SemanticsResolving {
     }
 
     func resolveInitializedType() -> EntityType {
-        EntityType.parseType(node.initializer.value)
+        EntityType(node.initializer.value)
     }
 
     func resolveInitializedTypeIsOptional() -> Bool {

--- a/Sources/SyntaxSparrow/Internal/Resolvers/Declaration/VariableSemanticsResolver.swift
+++ b/Sources/SyntaxSparrow/Internal/Resolvers/Declaration/VariableSemanticsResolver.swift
@@ -40,9 +40,9 @@ struct VariableSemanticsResolver: SemanticsResolving {
             else {
                 return .empty
             }
-            return EntityType.parseType(matchingType.type)
+            return EntityType(matchingType.type)
         }
-        return EntityType.parseType(typeAnnotation)
+        return EntityType(typeAnnotation)
     }
 
     func resolveName() -> String {

--- a/Sources/SyntaxSparrow/Internal/Resolvers/Syntax/ClosureSemanticsResolver.swift
+++ b/Sources/SyntaxSparrow/Internal/Resolvers/Syntax/ClosureSemanticsResolver.swift
@@ -39,7 +39,7 @@ struct ClosureSemanticsResolver: SemanticsResolving {
     }
 
     func resolveOutput() -> EntityType {
-        EntityType.parseType(node.output.returnType)
+        EntityType(node.output.returnType)
     }
 
     func resolveRawInput() -> String {

--- a/Sources/SyntaxSparrow/Internal/Resolvers/Syntax/EnumCaseParameterSemanticsResolver.swift
+++ b/Sources/SyntaxSparrow/Internal/Resolvers/Syntax/EnumCaseParameterSemanticsResolver.swift
@@ -52,7 +52,7 @@ struct EnumCaseParameterSemanticsResolver: ParameterNodeSemanticsResolving {
     }
 
     func resolveType() -> EntityType {
-        return EntityType.parseType(node.type)
+        return EntityType(node.type)
     }
 
     func resolveIsVariadic() -> Bool {

--- a/Sources/SyntaxSparrow/Internal/Resolvers/Syntax/FunctionParameterSemanticsResolver.swift
+++ b/Sources/SyntaxSparrow/Internal/Resolvers/Syntax/FunctionParameterSemanticsResolver.swift
@@ -52,7 +52,7 @@ struct FunctionParameterSemanticsResolver: ParameterNodeSemanticsResolving {
     }
 
     func resolveType() -> EntityType {
-        return EntityType.parseType(node.type)
+        return EntityType(node.type)
     }
 
     func resolveIsVariadic() -> Bool {

--- a/Sources/SyntaxSparrow/Internal/Resolvers/Syntax/ResultSemanticsResolver.swift
+++ b/Sources/SyntaxSparrow/Internal/Resolvers/Syntax/ResultSemanticsResolver.swift
@@ -40,7 +40,7 @@ struct ResultSemanticsResolver: SemanticsResolving {
         else {
             return .empty
         }
-        return EntityType.parseType(successType.argumentType)
+        return EntityType(successType.argumentType)
     }
 
     func resolveFailureType() -> EntityType {
@@ -51,6 +51,6 @@ struct ResultSemanticsResolver: SemanticsResolving {
         else {
             return .empty
         }
-        return EntityType.parseType(failureType.argumentType)
+        return EntityType(failureType.argumentType)
     }
 }

--- a/Sources/SyntaxSparrow/Internal/Resolvers/Syntax/TupleParameterSemanticsResolver.swift
+++ b/Sources/SyntaxSparrow/Internal/Resolvers/Syntax/TupleParameterSemanticsResolver.swift
@@ -56,7 +56,7 @@ struct TupleParameterSemanticsResolver: ParameterNodeSemanticsResolving {
     }
 
     func resolveType() -> EntityType {
-        return EntityType.parseType(node.type)
+        return EntityType(node.type)
     }
 
     func resolveIsVariadic() -> Bool {

--- a/Sources/SyntaxSparrow/Public/Protocols/SyntaxChildCollecting.swift
+++ b/Sources/SyntaxSparrow/Public/Protocols/SyntaxChildCollecting.swift
@@ -12,49 +12,52 @@ public protocol SyntaxChildCollecting {
     /// ``SyntaxSparrow/DeclarationCollection`` utility instance any results will be collected into.
     var childCollection: DeclarationCollection { get }
 
-    /// The collected class declarations.
+    /// The collected ``Actor`` declarations.
+    var actors: [Actor] { get }
+
+    /// The collected ``Class`` declarations.
     var classes: [Class] { get }
 
-    /// The collected conditional compilation block declarations.
+    /// The collected ``ConditionalCompilationBlock`` declarations.
     var conditionalCompilationBlocks: [ConditionalCompilationBlock] { get }
 
-    /// The collected deinitializer declarations.
+    /// The collected ``Deinitializer`` declarations.
     var deinitializers: [Deinitializer] { get }
 
-    /// The collected enumeration declarations.
+    /// The collected ``Enumeration`` declarations.
     var enumerations: [Enumeration] { get }
 
-    /// The collected extension declarations.
+    /// The collected ``Extension`` declarations.
     var extensions: [Extension] { get }
 
-    /// The collected function declarations.
+    /// The collected ``Function`` declarations.
     var functions: [Function] { get }
 
-    /// The collected import declarations.
+    /// The collected ``Import`` declarations.
     var imports: [Import] { get }
 
-    /// The collected initializer declarations.
+    /// The collected ``Initializer`` declarations.
     var initializers: [Initializer] { get }
 
-    /// The collected operator declarations.
+    /// The collected ``Operator`` declarations.
     var operators: [Operator] { get }
 
-    /// The collected precedence group declarations.
+    /// The collected ``PrecedenceGroup`` declarations.
     var precedenceGroups: [PrecedenceGroup] { get }
 
-    /// The collected protocol declarations.
+    /// The collected ``ProtocolDecl`` declarations.
     var protocols: [ProtocolDecl] { get }
 
-    /// The collected structure declarations.
+    /// The collected ``Structure`` declarations.
     var structures: [Structure] { get }
 
-    /// The collected subscript declarations.
+    /// The collected ``Subscript`` declarations.
     var subscripts: [Subscript] { get }
 
-    /// The collected type alias declarations.
+    /// The collected ``Typealias`` declarations.
     var typealiases: [Typealias] { get }
 
-    /// The collected variable declarations.
+    /// The collected ``Variable`` declarations.
     var variables: [Variable] { get }
 
     /// Will reset the collected child instances and re-assess the represented node to collect any supported child declarations.
@@ -84,5 +87,128 @@ public extension SyntaxChildCollecting where Self: Declaration {
         let collector = RootDeclarationCollector(viewMode: viewMode)
         let collection = collector.collect(fromNode: node)
         childCollection.collect(from: collection)
+    }
+}
+
+public extension SyntaxChildCollecting where Self: DeclarationComponent {
+    var actors: [Actor] { childCollection.actors }
+    var classes: [Class] { childCollection.classes }
+    var conditionalCompilationBlocks: [ConditionalCompilationBlock] { childCollection.conditionalCompilationBlocks }
+    var deinitializers: [Deinitializer] { childCollection.deinitializers }
+    var enumerations: [Enumeration] { childCollection.enumerations }
+    var extensions: [Extension] { childCollection.extensions }
+    var functions: [Function] { childCollection.functions }
+    var imports: [Import] { childCollection.imports }
+    var initializers: [Initializer] { childCollection.initializers }
+    var operators: [Operator] { childCollection.operators }
+    var precedenceGroups: [PrecedenceGroup] { childCollection.precedenceGroups }
+    var protocols: [ProtocolDecl] { childCollection.protocols }
+    var structures: [Structure] { childCollection.structures }
+    var subscripts: [Subscript] { childCollection.subscripts }
+    var typealiases: [Typealias] { childCollection.typealiases }
+    var variables: [Variable] { childCollection.variables }
+
+    func collectChildren(viewMode: SyntaxTreeViewMode) {
+        let collector = RootDeclarationCollector(viewMode: viewMode)
+        let collection = collector.collect(fromNode: node)
+        childCollection.collect(from: collection)
+    }
+}
+
+public extension SyntaxChildCollecting {
+    
+    /// Will recursively iterate through the collected declarations **on the current declaration** for the given type and return them in a flattened array.
+    ///
+    /// Note: Declarations are returned **in order of declaration**
+    ///
+    /// For example,
+    /// ```swift
+    /// enum Container {
+    ///    struct NestedStruct {
+    ///        struct NestedStructTwo {
+    ///            enum NestedContainer {}
+    ///        }
+    ///    }
+    /// }
+    /// struct RootLevelStruct {}
+    /// ```
+    /// If you invoke the `recursivelyCollectDeclarations(Structure.self)` helper on the root `SyntaxTree` instance would return:
+    /// - [`Structure<NesedStruct>`, `Structure<NestedStructTwo>`, `Structure<RootLevelStruct>`]
+    /// if you invoke the helper on the `tree.enumerations[0]` instance would return:
+    /// - [`Structure<NesedStruct>`, `Structure<NestedStructTwo>`]
+    ///
+    /// - Parameter type: The type to collect
+    /// - Returns: Array of the inferred `Declaration` type
+    func recursivelyCollectDeclarations<T: Declaration>(of type: T.Type) -> [T] {
+        let rootLevels = childDeclarations(of: type, from: self)
+        let targets = syntaxChildCollectingDeclarations(from: self)
+        //let rootLevels = targets.flatMap { childDeclarations(of: type, from: $0) }
+        let nested = targets.flatMap { $0.recursivelyCollectDeclarations(of: type) }
+        let results = (rootLevels + nested).sorted(by: { $0.node.position.utf8Offset < $1.node.position.utf8Offset })
+        return results
+    }
+
+    // MARK: - Helpers: Private
+
+    private func syntaxChildCollectingDeclarations(from childCollecting: SyntaxChildCollecting) -> [SyntaxChildCollecting] {
+        var targets: [any SyntaxChildCollecting] = []
+        targets.append(contentsOf: childCollecting.actors)
+        targets.append(contentsOf: childCollecting.classes)
+        let branches = childCollecting.conditionalCompilationBlocks.flatMap(\.branches)
+        targets.append(contentsOf: branches)
+        targets.append(contentsOf: childCollecting.deinitializers)
+        targets.append(contentsOf: childCollecting.enumerations)
+        targets.append(contentsOf: childCollecting.extensions)
+        targets.append(contentsOf: childCollecting.functions)
+        targets.append(contentsOf: childCollecting.initializers)
+        targets.append(contentsOf: childCollecting.protocols)
+        targets.append(contentsOf: childCollecting.structures)
+        // accessors
+        let subscriptAccessors = childCollecting.subscripts.flatMap(\.accessors)
+        targets.append(contentsOf: subscriptAccessors)
+        let variableAccessors = childCollecting.variables.flatMap(\.accessors)
+        targets.append(contentsOf: variableAccessors)
+        return targets
+    }
+
+    private func childDeclarations<T: Declaration>(of type: T.Type, from childCollecting: SyntaxChildCollecting) -> [T] {
+        var result: [Any] = []
+        switch type {
+        case is Actor.Type:
+            result = childCollecting.actors
+        case is Class.Type:
+            result = childCollecting.classes
+        case is ConditionalCompilationBlock.Type:
+            result = childCollecting.conditionalCompilationBlocks
+        case is Deinitializer.Type:
+            result = childCollecting.deinitializers
+        case is Enumeration.Type:
+            result = childCollecting.enumerations
+        case is Extension.Type:
+            result = childCollecting.extensions
+        case is Function.Type:
+            result = childCollecting.functions
+        case is Import.Type:
+            result = childCollecting.imports
+        case is Initializer.Type:
+            result = childCollecting.initializers
+        case is Operator.Type:
+            result = childCollecting.operators
+        case is PrecedenceGroup.Type:
+            result = childCollecting.precedenceGroups
+        case is ProtocolDecl.Type:
+            result = childCollecting.protocols
+        case is Structure.Type:
+            result = childCollecting.structures
+        case is Subscript.Type:
+            result = childCollecting.subscripts
+        case is Typealias.Type:
+            result = childCollecting.typealiases
+        case is Variable.Type:
+            result = childCollecting.variables
+        default:
+            break
+        }
+        return (result as? [T]) ?? []
     }
 }

--- a/Sources/SyntaxSparrow/Public/Semantics/Components/Accessor.swift
+++ b/Sources/SyntaxSparrow/Public/Semantics/Components/Accessor.swift
@@ -19,7 +19,7 @@ import SwiftSyntax
 /// - Modifier applied to the accessor, e.g., `private`.
 ///
 /// The `Accessor` struct also includes functionality to create an accessor instance from an `AccessorDeclSyntax` node.
-public struct Accessor: DeclarationComponent {
+public struct Accessor: DeclarationComponent, SyntaxChildCollecting {
     // MARK: - Supplementary
 
     /// The kind of accessor (`get` or `set`).
@@ -81,6 +81,12 @@ public struct Accessor: DeclarationComponent {
     /// ```
     public let body: CodeBlock?
 
+    // MARK: - Properties: SyntaxChildCollecting
+
+    public var childCollection: DeclarationCollection {
+        body?.childCollection ?? DeclarationCollection()
+    }
+
     // MARK: - Lifecycle
 
     /// Creates a new ``SyntaxSparrow/Accessor`` instance from an `AccessorDeclSyntax` node.
@@ -109,5 +115,12 @@ public struct Accessor: DeclarationComponent {
         } else {
             effectSpecifiers = nil
         }
+        collectChildren(viewMode: .fixedUp)
+    }
+
+    // MARK: - Conformance: SyntaxChildCollecting
+
+    public func collectChildren(viewMode: SyntaxTreeViewMode) {
+        body?.collectChildren(viewMode: viewMode)
     }
 }

--- a/Sources/SyntaxSparrow/Public/Semantics/Components/CodeBlock.swift
+++ b/Sources/SyntaxSparrow/Public/Semantics/Components/CodeBlock.swift
@@ -12,8 +12,8 @@ import SwiftSyntax
 ///
 /// A code block is primarily a list of code statements within parenthesis `{` and `}`. For example, the `get/set/willSet/didSet` accessors in a variable, a function body etc.
 ///
-/// An instance of the `CodeBlock` struct provides access to an array of statements held within.
-public struct CodeBlock: DeclarationComponent {
+/// An instance of the `CodeBlock` struct provides access to an array of statements held within. It also supports ``SyntaxChildCollecting`` which can collect child declarations.
+public struct CodeBlock: DeclarationComponent, SyntaxChildCollecting {
     // MARK: - Supplementary
 
     /// The kind of accessor (`get` or `set`).
@@ -34,11 +34,16 @@ public struct CodeBlock: DeclarationComponent {
     /// Array of statements within the code block.
     public let statements: [Statement]
 
+    // MARK: - Properties: SyntaxChildCollecting
+
+    public var childCollection: DeclarationCollection = .init()
+
     // MARK: - Lifecycle
 
     /// Creates a new ``SyntaxSparrow/CodeBlock`` instance from a `CodeBlockSyntax` node.
     public init(node: CodeBlockSyntax) {
         self.node = node
         statements = node.statements.map { Statement(node: $0) }
+        collectChildren(viewMode: .fixedUp)
     }
 }

--- a/Sources/SyntaxSparrow/Public/Semantics/Components/EntityType.swift
+++ b/Sources/SyntaxSparrow/Public/Semantics/Components/EntityType.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SwiftSyntax
 
 /// An ``EntityType`` represents a type being referenced by a property or parameter. It is encapsulated in the ``EntityType``
 /// enumeration to provide a more simple entry point when working with sets of parameter inputs and properties.
@@ -88,5 +89,12 @@ public enum EntityType: Equatable, Hashable, CustomStringConvertible {
         case .empty:
             return ""
         }
+    }
+
+    // MARK: - Lifecycle
+
+    /// Creates a new ``SyntaxSparrow/EntityType`` instance from a `TypeSyntax` node.
+    public init(_ typeSyntax: TypeSyntax) {
+        self = EntityType.parseType(typeSyntax)
     }
 }

--- a/Sources/SyntaxSparrow/Public/Semantics/Declarations/Deinitializer.swift
+++ b/Sources/SyntaxSparrow/Public/Semantics/Declarations/Deinitializer.swift
@@ -39,17 +39,37 @@ public struct Deinitializer: Declaration, SyntaxChildCollecting {
     /// i.e: `"class"`
     public var keyword: String { resolver.resolveKeyword() }
 
+    /// Struct representing the body of the function.
+    ///
+    /// For example in the following declaration:
+    /// ```swift
+    /// func deinit() {
+    ///     print("hello")
+    ///     print("world")
+    /// }
+    /// ```
+    /// would provide a `body` that is not `nil` and would have 2 statements within it.
+    public var body: CodeBlock? { resolver.resolveBody() }
+
     // MARK: - Properties: Resolving
 
     private(set) var resolver: DeinitializerSemanticsResolver
 
     // MARK: - Properties: SyntaxChildCollecting
 
-    public var childCollection: DeclarationCollection = .init()
+    // Note: The `CodeBlock` type supports collecting child declarations. The deinit will default to using that collection.
+
+    public var childCollection: DeclarationCollection {
+        body?.childCollection ?? DeclarationCollection()
+    }
 
     // MARK: - Lifecycle
 
     public init(node: DeinitializerDeclSyntax) {
         resolver = DeinitializerSemanticsResolver(node: node)
+    }
+
+    public func collectChildren(viewMode: SyntaxTreeViewMode) {
+        body?.collectChildren(viewMode: viewMode)
     }
 }

--- a/Sources/SyntaxSparrow/Public/Semantics/Declarations/Function.swift
+++ b/Sources/SyntaxSparrow/Public/Semantics/Declarations/Function.swift
@@ -172,11 +172,21 @@ public struct Function: Declaration, SyntaxChildCollecting {
 
     // MARK: - Properties: SyntaxChildCollecting
 
-    public var childCollection: DeclarationCollection = .init()
+    // Note: The `CodeBlock` type supports collecting child declarations. The function will default to using that collection.
+
+    public var childCollection: DeclarationCollection {
+        body?.childCollection ?? DeclarationCollection()
+    }
 
     // MARK: - Lifecycle
 
     public init(node: FunctionDeclSyntax) {
         resolver = FunctionSemanticsResolver(node: node)
+    }
+
+    // MARK: - Conformance: SyntaxChildCollecting
+
+    public func collectChildren(viewMode: SyntaxTreeViewMode) {
+        body?.collectChildren(viewMode: viewMode)
     }
 }

--- a/Sources/SyntaxSparrow/Public/Semantics/Declarations/Initializer.swift
+++ b/Sources/SyntaxSparrow/Public/Semantics/Declarations/Initializer.swift
@@ -90,17 +90,39 @@ public struct Initializer: Declaration, SyntaxChildCollecting {
     /// **Note:** `effectSpecifiers` will be `nil` if no specifiers are found on the node.
     public var effectSpecifiers: EffectSpecifiers? { resolver.resolveEffectSpecifiers() }
 
+    /// Struct representing the body of the function.
+    ///
+    /// For example in the following declaration:
+    /// ```swift
+    /// init() {
+    ///     print("hello")
+    ///     print("world")
+    /// }
+    /// ```
+    /// would provide a `body` that is not `nil` and would have 2 statements within it.
+    public var body: CodeBlock? { resolver.resolveBody() }
+
     // MARK: - Properties: Resolving
 
     private(set) var resolver: InitializerSemanticsResolver
 
     // MARK: - Properties: SyntaxChildCollecting
 
-    public var childCollection: DeclarationCollection = .init()
+    // Note: The `CodeBlock` type supports collecting child declarations. The init will default to using that collection.
+
+    public var childCollection: DeclarationCollection {
+        body?.childCollection ?? DeclarationCollection()
+    }
 
     // MARK: - Lifecycle
 
     public init(node: InitializerDeclSyntax) {
         resolver = InitializerSemanticsResolver(node: node)
+    }
+
+    // MARK: - Conformance: SyntaxChildCollecting
+
+    public func collectChildren(viewMode: SyntaxTreeViewMode) {
+        body?.collectChildren(viewMode: viewMode)
     }
 }

--- a/Sources/SyntaxSparrow/Public/SyntaxTree/SyntaxTree+Convenience.swift
+++ b/Sources/SyntaxSparrow/Public/SyntaxTree/SyntaxTree+Convenience.swift
@@ -83,6 +83,8 @@ public extension SyntaxTree {
     func declarations<T: Declaration>(of type: T.Type) -> [T] {
         var result: [Any] = []
         switch type {
+        case is Actor.Type:
+            result = actors
         case is Class.Type:
             result = classes
         case is ConditionalCompilationBlock.Type:

--- a/Tests/SyntaxSparrowTests/SyntaxChildCollecting+ConvenienceTests.swift
+++ b/Tests/SyntaxSparrowTests/SyntaxChildCollecting+ConvenienceTests.swift
@@ -1,0 +1,162 @@
+//
+//  SyntaxChildCollectingConvenienceTests.swift
+//
+//
+//  Created by Michael O'Brien on 9/7/2023.
+//
+
+import SwiftSyntax
+import SyntaxSparrow
+import XCTest
+
+final class SyntaxChildCollectingConvenienceTests: XCTestCase {
+    // MARK: - Properties
+
+    var instanceUnderTest: SyntaxTree!
+
+    // MARK: - Lifecycle
+
+    override func setUpWithError() throws {
+        instanceUnderTest = SyntaxTree(viewMode: .sourceAccurate, sourceBuffer: "")
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    // MARK: - Tests
+
+    func test_recursivelyCollectDeclarations_willResolveExpectedChildDeclarations() throws {
+        let source = #"""
+        enum Container {
+            typealias NestedTypeAliasOne = String
+            actor NestedActorOne {}
+            func executeOrder66() {
+
+                struct NestedStructOne {
+
+                    typealias NestedTypeAliasTwo = String
+
+                    func executeOrder66Two() {
+                        struct NestedStructTwo {}
+                        class NestedClassOne {
+                            init(nestedInitializerOne: Int) {}
+                            deinit { print("Nested deinit one") }
+                        }
+                        enum NestedEnumOne { case nested }
+                        actor NestedActorTwo {}
+                        typealias NestedTypeAliasThree = String
+                        func nestedFunctionOne() {}
+                        var nestedVariableOne: Int = 0
+                        infix operator ++: NestedOperatorOne
+                        subscript(nestedSubscriptOne idx: Int) -> Int { return idx }
+                        func executeOrder66Three() {
+                            struct NestedStructThree {}
+                            class NestedClassTwo {}
+                            enum NestedEnumTwo { case nested }
+                            typealias NestedTypeAliasFour = String
+                            func nestedFunctionTwo() {}
+                            var nestedVariableTwo: Int = 0
+                        }
+                    }
+                }
+                #if NESTED_CONDITIONAL_ONE
+                print("nested")
+                #else
+                print("nested")
+                #endif
+
+                class NestedClassThree {}
+                enum NestedEnumThree { case nested }
+                typealias NestedTypeAliasFive = String
+                func nestedFunctionThree() {}
+                var nestedVariableThree: Int = 0
+                protocol NestedProtocol {}
+                subscript(nestedSubscriptTwo idx: Int) -> Int { return idx }
+                init(nestedInitializerTwo: Int) {}
+                deinit { print("Nested deinit two") }
+                infix operator +-: NestedOperatorTwo
+                deinit {
+                    print("Nested deinit three")
+                    #if NESTED_CONDITIONAL_TWO
+                    print("nested")
+                    #else
+                    print("nested")
+                    #endif
+                    var nestedVariableFour: Int = 0
+                }
+            }
+            typealias NestedTypeAliasSix = String
+            actor NestedActorThree {}
+            #if NESTED_CONDITIONAL_THREE
+            print("nested")
+            #else
+            print("nested")
+            #endif
+        }
+        """#
+        instanceUnderTest.updateToSource(source)
+        XCTAssertTrue(instanceUnderTest.isStale)
+        instanceUnderTest.collectChildren()
+        XCTAssertFalse(instanceUnderTest.isStale)
+        XCTAssertEqual(instanceUnderTest.enumerations.count, 1)
+        // Enums
+        let enums = instanceUnderTest.recursivelyCollectDeclarations(of: Enumeration.self)
+        XCTAssertEqual(enums.count, 4)
+        XCTAssertEqual(enums.map(\.name), ["Container", "NestedEnumOne", "NestedEnumTwo", "NestedEnumThree"])
+        // Typealiases
+        let aliases = instanceUnderTest.recursivelyCollectDeclarations(of: Typealias.self)
+        XCTAssertEqual(aliases.count, 6)
+        XCTAssertEqual(aliases.map(\.name), [
+            "NestedTypeAliasOne", "NestedTypeAliasTwo", "NestedTypeAliasThree", "NestedTypeAliasFour", "NestedTypeAliasFive", "NestedTypeAliasSix"
+        ])
+        // Functions
+        let functions = instanceUnderTest.recursivelyCollectDeclarations(of: Function.self)
+        XCTAssertEqual(functions.count, 6)
+        XCTAssertEqual(functions.map(\.identifier), [
+            "executeOrder66", "executeOrder66Two", "nestedFunctionOne", "executeOrder66Three", "nestedFunctionTwo", "nestedFunctionThree"
+        ])
+        // Structs
+        let structures = instanceUnderTest.recursivelyCollectDeclarations(of: Structure.self)
+        XCTAssertEqual(structures.count, 3)
+        XCTAssertEqual(structures.map(\.name), ["NestedStructOne", "NestedStructTwo", "NestedStructThree"])
+        // Classes
+        let classes = instanceUnderTest.recursivelyCollectDeclarations(of: Class.self)
+        XCTAssertEqual(classes.count, 3)
+        XCTAssertEqual(classes.map(\.name), ["NestedClassOne", "NestedClassTwo", "NestedClassThree"])
+        // Variables
+        let variables = instanceUnderTest.recursivelyCollectDeclarations(of: Variable.self)
+        XCTAssertEqual(variables.count, 4)
+        XCTAssertEqual(variables.map(\.name), ["nestedVariableOne", "nestedVariableTwo", "nestedVariableThree", "nestedVariableFour"])
+        // Subscripts
+        let subscripts = instanceUnderTest.recursivelyCollectDeclarations(of: Subscript.self)
+        let indexNames = subscripts.flatMap { $0.indices.compactMap(\.name) }
+        XCTAssertEqual(subscripts.count, 2)
+        XCTAssertEqual(indexNames, ["nestedSubscriptOne", "nestedSubscriptTwo"])
+        // Actors
+        let actors = instanceUnderTest.recursivelyCollectDeclarations(of: Actor.self)
+        XCTAssertEqual(actors.count, 3)
+        XCTAssertEqual(actors.map(\.name), ["NestedActorOne", "NestedActorTwo", "NestedActorThree"])
+        // Initializers
+        let inits = instanceUnderTest.recursivelyCollectDeclarations(of: Initializer.self)
+        let inputNames = inits.flatMap { $0.parameters.compactMap(\.name) }
+        XCTAssertEqual(inits.count, 2)
+        XCTAssertEqual(inputNames, ["nestedInitializerOne", "nestedInitializerTwo"])
+        // DeInitializers
+        let deinits = instanceUnderTest.recursivelyCollectDeclarations(of: Deinitializer.self)
+        let bodyStatements = deinits.flatMap { $0.body!.statements.map(\.description) }
+        XCTAssertEqual(inits.count, 2)
+        XCTAssertTrue(bodyStatements[0].contains("Nested deinit one"))
+        XCTAssertTrue(bodyStatements[1].contains("Nested deinit two"))
+        XCTAssertTrue(bodyStatements[2].contains("Nested deinit three"))
+        // Operator
+        let ops = instanceUnderTest.recursivelyCollectDeclarations(of: Operator.self)
+        XCTAssertEqual(ops.count, 2)
+        XCTAssertEqual(ops.map(\.name), ["++", "+-"])
+        // Conditionals
+        let conditionals = instanceUnderTest.recursivelyCollectDeclarations(of: ConditionalCompilationBlock.self)
+        let branchConditions = conditionals.flatMap { $0.branches.compactMap(\.condition)}
+        XCTAssertEqual(conditionals.count, 3)
+        XCTAssertEqual(branchConditions, ["NESTED_CONDITIONAL_ONE", "NESTED_CONDITIONAL_TWO", "NESTED_CONDITIONAL_THREE"])
+    }
+}

--- a/Tests/SyntaxSparrowTests/SyntaxSparrowTests.swift
+++ b/Tests/SyntaxSparrowTests/SyntaxSparrowTests.swift
@@ -11,6 +11,7 @@ import XCTest
 private extension DeclarationCollection {
     var allDeclarations: [any Declaration] {
         var results: [any Declaration] = []
+        results.append(contentsOf: actors)
         results.append(contentsOf: classes)
         results.append(contentsOf: conditionalCompilationBlocks)
         results.append(contentsOf: deinitializers)


### PR DESCRIPTION
- Exposes `EntityType` init method with `TypeSyntax`
- Adds missing `actors` convenience getter to protocols and conformance for `SyntaxChildCollecting`
- Exposes convenience method on `SyntaxChildCollecting` for recursively getting declaration types into a flattened array.
- Adds `SyntaxChildCollecting` support to `CodeBlock`
- Added unit test coverage for additions