### PR TITLE
Adding support for Swift Array, Dictionary, and Set to EntityType

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -32,7 +32,7 @@ jobs:
         swift: ["5.9", "5.8", "5.7"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: swift-actions/setup-swift@65540b95f51493d65f5e59e97dcef9629ddf11bf
+      - uses: swift-actions/setup-swift@v1
         with:
           swift-version: ${{ matrix.swift }}
       - uses: actions/checkout@v3

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest]
-        swift: ["5.8", "5.7"]
+        swift: ["5.9", "5.8", "5.7"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: swift-actions/setup-swift@65540b95f51493d65f5e59e97dcef9629ddf11bf

--- a/README.md
+++ b/README.md
@@ -229,6 +229,9 @@ The various EntityType options include:
 - simple: Represents a simple type like `Int`, `String`, `Bool`, or any other user-defined types.
 - tuple: Represents tuple types, such as `(Int, String)`
 - closure: Represents function or closure types, like `(Int, String) -> Bool`
+- Array: Represents a swift array via shorthand `[Type]` or keyword `Array<Type>` 
+- Set: Represents a swift set via keyword `Set<Type>` 
+- Dictionary: Represents a swift dictionary via shorthand `[Type: Type]` or keyword `Dictionary<Type, Type>` 
 - result: Represents Swift's Result type, capturing the Success and Failure types.
 - void: Represents a void block type. i.e `Void` or `()`
 - empty: Used to capture partial declarations where a type is not defined yet. i.e `var myName: `
@@ -279,7 +282,7 @@ Currently, SyntaxSparrow supports Swift Package Manager (SPM).
 To add SyntaxSparrow to your project, add the following line to your dependencies in your Package.swift file:
 
 ```swift
-.package(url: "https://github.com/CheekyGhost-Labs/SyntaxSparrow", from: "2.0.0")
+.package(url: "https://github.com/CheekyGhost-Labs/SyntaxSparrow", from: "3.0.0")
 ```
 
 Then, add SyntaxSparrow as a dependency for your target:

--- a/README.md
+++ b/README.md
@@ -254,6 +254,18 @@ case .simple(let typeName):
 case .tuple(let tuple):
     tuple.isOptional // true/false
     tuple.elements // Array of `Parameter` types
+case .array(let array):
+    array.isOptional // true/false
+    array.elementType // Entity Type
+    array.declType // .squareBrackets/.generic
+case .set(let set):
+    set.isOptional // true/false
+    set.elementType // Entity Type
+case .dictionary(let dict):
+    dict.isOptional // true/false
+    dict.keyType // Entity Type
+    dict.valueType // Entity Type
+    dict.declType // .squareBrackets/.generics
 case .closure(let closure):
     closure.input // Entity Type
     closure.output // Entity Type

--- a/Sources/SyntaxSparrow/Internal/Extensions/EntityType+Parsing.swift
+++ b/Sources/SyntaxSparrow/Internal/Extensions/EntityType+Parsing.swift
@@ -22,9 +22,12 @@ extension EntityType {
         // Simple
         if let simpleType = typeSyntax.as(IdentifierTypeSyntax.self) {
             // Result
-            if simpleType.firstToken(viewMode: .fixedUp)?.tokenKind == .identifier("Result") {
-                let result = Result(simpleType)
-                return .result(result!)
+            if let resultType = Result(simpleType) {
+                return .result(resultType)
+            }
+            // Array
+            if let arrayType = Array(simpleType) {
+                return .array(arrayType)
             }
             let isOptional = simpleType.resolveIsTypeOptional()
             // Void check
@@ -37,6 +40,12 @@ extension EntityType {
 
             let typeString = resolveSimpleTypeString(from: simpleType)
             return .simple(typeString)
+        }
+
+        // Array
+        if let arrayTypeSyntax = typeSyntax.as(ArrayTypeSyntax.self) {
+            let array = Array(arrayTypeSyntax)
+            return .array(array)
         }
 
         // Tuple

--- a/Sources/SyntaxSparrow/Internal/Extensions/EntityType+Parsing.swift
+++ b/Sources/SyntaxSparrow/Internal/Extensions/EntityType+Parsing.swift
@@ -26,8 +26,12 @@ extension EntityType {
                 return .result(resultType)
             }
             // Array
-            if let arrayType = Array(simpleType) {
+            if let arrayType = ArrayDecl(simpleType) {
                 return .array(arrayType)
+            }
+            // Set
+            if let setType = SetDecl(simpleType) {
+                return .set(setType)
             }
             let isOptional = simpleType.resolveIsTypeOptional()
             // Void check
@@ -44,7 +48,7 @@ extension EntityType {
 
         // Array
         if let arrayTypeSyntax = typeSyntax.as(ArrayTypeSyntax.self) {
-            let array = Array(arrayTypeSyntax)
+            let array = ArrayDecl(arrayTypeSyntax)
             return .array(array)
         }
 

--- a/Sources/SyntaxSparrow/Internal/Extensions/EntityType+Parsing.swift
+++ b/Sources/SyntaxSparrow/Internal/Extensions/EntityType+Parsing.swift
@@ -33,6 +33,10 @@ extension EntityType {
             if let setType = SetDecl(simpleType) {
                 return .set(setType)
             }
+            // Dictionary
+            if let dictType = DictionaryDecl(simpleType) {
+                return .dictionary(dictType)
+            }
             let isOptional = simpleType.resolveIsTypeOptional()
             // Void check
             if
@@ -50,6 +54,12 @@ extension EntityType {
         if let arrayTypeSyntax = typeSyntax.as(ArrayTypeSyntax.self) {
             let array = ArrayDecl(arrayTypeSyntax)
             return .array(array)
+        }
+
+        // Dictionary
+        if let dictTypeSyntax = typeSyntax.as(DictionaryTypeSyntax.self) {
+            let dict = DictionaryDecl(dictTypeSyntax)
+            return .dictionary(dict)
         }
 
         // Tuple

--- a/Sources/SyntaxSparrow/Internal/Resolvers/Syntax/ArraySemanticsResolving.swift
+++ b/Sources/SyntaxSparrow/Internal/Resolvers/Syntax/ArraySemanticsResolving.swift
@@ -1,0 +1,65 @@
+//
+//  FunctionSemanticsResolver.swift
+//
+//
+//  Copyright (c) CheekyGhost Labs 2023. All Rights Reserved.
+//
+
+import Foundation
+import SwiftSyntax
+
+protocol ArraySemanticsResolving: SemanticsResolving {
+    func resolveElementType() -> EntityType
+    func resolveIsOptional() -> Bool
+}
+
+struct ArrayIdentifierSemanticsResolver: ArraySemanticsResolving {
+    // MARK: - Properties: SemanticsResolving
+
+    typealias Node = IdentifierTypeSyntax
+
+    let node: Node
+
+    // MARK: - Lifecycle
+
+    init(node: IdentifierTypeSyntax) {
+        self.node = node
+    }
+
+    // MARK: - Resolvers
+
+    func resolveElementType() -> EntityType {
+        guard let typeArg = node.genericArgumentClause?.arguments.first else {
+            return .empty
+        }
+        return EntityType(typeArg.argument)
+    }
+
+    func resolveIsOptional() -> Bool {
+        node.resolveIsSyntaxOptional(viewMode: .fixedUp)
+    }
+}
+
+struct ArrayTypeSemanticsResolver: ArraySemanticsResolving {
+    // MARK: - Properties: SemanticsResolving
+
+    typealias Node = ArrayTypeSyntax
+
+    let node: Node
+
+    // MARK: - Lifecycle
+
+    init(node: ArrayTypeSyntax) {
+        self.node = node
+    }
+
+    // MARK: - Resolvers
+
+    func resolveElementType() -> EntityType {
+        EntityType(node.element)
+    }
+
+    func resolveIsOptional() -> Bool {
+        node.resolveIsSyntaxOptional(viewMode: .fixedUp)
+    }
+}

--- a/Sources/SyntaxSparrow/Internal/Resolvers/Syntax/DictionarySemanticsResolving.swift
+++ b/Sources/SyntaxSparrow/Internal/Resolvers/Syntax/DictionarySemanticsResolving.swift
@@ -14,7 +14,7 @@ protocol DictionarySemanticsResolving: SemanticsResolving {
     func resolveIsOptional() -> Bool
 }
 
-struct DictionaryIdentifierSemanticsResolver: ArraySemanticsResolving {
+struct DictionaryIdentifierSemanticsResolver: DictionarySemanticsResolving {
     // MARK: - Properties: SemanticsResolving
 
     typealias Node = IdentifierTypeSyntax
@@ -48,7 +48,7 @@ struct DictionaryIdentifierSemanticsResolver: ArraySemanticsResolving {
     }
 }
 
-struct DictionaryTypeSemanticsResolver: ArraySemanticsResolving {
+struct DictionaryTypeSemanticsResolver: DictionarySemanticsResolving {
     // MARK: - Properties: SemanticsResolving
 
     typealias Node = DictionaryTypeSyntax

--- a/Sources/SyntaxSparrow/Internal/Resolvers/Syntax/DictionarySemanticsResolving.swift
+++ b/Sources/SyntaxSparrow/Internal/Resolvers/Syntax/DictionarySemanticsResolving.swift
@@ -8,13 +8,13 @@
 import Foundation
 import SwiftSyntax
 
-protocol ArraySemanticsResolving: SemanticsResolving {
+protocol DictionarySemanticsResolving: SemanticsResolving {
+    func resolveKeyType() -> EntityType
     func resolveElementType() -> EntityType
     func resolveIsOptional() -> Bool
 }
 
-struct ArrayIdentifierSemanticsResolver: ArraySemanticsResolving {
-
+struct DictionaryIdentifierSemanticsResolver: ArraySemanticsResolving {
     // MARK: - Properties: SemanticsResolving
 
     typealias Node = IdentifierTypeSyntax
@@ -29,8 +29,15 @@ struct ArrayIdentifierSemanticsResolver: ArraySemanticsResolving {
 
     // MARK: - Resolvers
 
-    func resolveElementType() -> EntityType {
+    func resolveKeyType() -> EntityType {
         guard let typeArg = node.genericArgumentClause?.arguments.first else {
+            return .empty
+        }
+        return EntityType(typeArg.argument)
+    }
+
+    func resolveElementType() -> EntityType {
+        guard let typeArg = node.genericArgumentClause?.arguments.last else {
             return .empty
         }
         return EntityType(typeArg.argument)
@@ -41,23 +48,27 @@ struct ArrayIdentifierSemanticsResolver: ArraySemanticsResolving {
     }
 }
 
-struct ArrayTypeSemanticsResolver: ArraySemanticsResolving {
+struct DictionaryTypeSemanticsResolver: ArraySemanticsResolving {
     // MARK: - Properties: SemanticsResolving
 
-    typealias Node = ArrayTypeSyntax
+    typealias Node = DictionaryTypeSyntax
 
     let node: Node
 
     // MARK: - Lifecycle
 
-    init(node: ArrayTypeSyntax) {
+    init(node: DictionaryTypeSyntax) {
         self.node = node
     }
 
     // MARK: - Resolvers
 
+    func resolveKeyType() -> EntityType {
+        return EntityType(node.key)
+    }
+
     func resolveElementType() -> EntityType {
-        EntityType(node.element)
+        EntityType(node.value)
     }
 
     func resolveIsOptional() -> Bool {

--- a/Sources/SyntaxSparrow/Internal/Resolvers/Syntax/SetSemanticsResolver.swift
+++ b/Sources/SyntaxSparrow/Internal/Resolvers/Syntax/SetSemanticsResolver.swift
@@ -8,12 +8,7 @@
 import Foundation
 import SwiftSyntax
 
-protocol ArraySemanticsResolving: SemanticsResolving {
-    func resolveElementType() -> EntityType
-    func resolveIsOptional() -> Bool
-}
-
-struct ArrayIdentifierSemanticsResolver: ArraySemanticsResolving {
+struct SetSemanticsResolver: SemanticsResolving {
 
     // MARK: - Properties: SemanticsResolving
 
@@ -34,30 +29,6 @@ struct ArrayIdentifierSemanticsResolver: ArraySemanticsResolving {
             return .empty
         }
         return EntityType(typeArg.argument)
-    }
-
-    func resolveIsOptional() -> Bool {
-        node.resolveIsSyntaxOptional(viewMode: .fixedUp)
-    }
-}
-
-struct ArrayTypeSemanticsResolver: ArraySemanticsResolving {
-    // MARK: - Properties: SemanticsResolving
-
-    typealias Node = ArrayTypeSyntax
-
-    let node: Node
-
-    // MARK: - Lifecycle
-
-    init(node: ArrayTypeSyntax) {
-        self.node = node
-    }
-
-    // MARK: - Resolvers
-
-    func resolveElementType() -> EntityType {
-        EntityType(node.element)
     }
 
     func resolveIsOptional() -> Bool {

--- a/Sources/SyntaxSparrow/Public/Semantics/Components/Array.swift
+++ b/Sources/SyntaxSparrow/Public/Semantics/Components/Array.swift
@@ -1,0 +1,90 @@
+//
+//  File.swift
+//  
+//
+//  Created by Michael O'Brien on 14/11/2023.
+//
+
+import Foundation
+import SwiftSyntax
+
+/// Represents a Swift `Array` type.
+///
+/// In Swift, arrays are used to store ordered collections of values. The `Array` struct 
+/// encapsulates an array type from a Swift source file and provides access to the element type.
+///
+/// The element type is represented as an `EntityType` instance. For example, for the array type `Array<String>`
+/// or `[String]`, the element type will be `.simple("String")`.
+///
+/// This struct provides functionality to create an `Array` instance from either an `ArrayTypeSyntax` node
+/// or a `IdentifierTypeSyntax` node with `Array` as the identifier. The struct also distinguishes between
+/// arrays declared using square brackets (e.g., `[String]`) and those declared using the `Array` keyword
+/// with generics (e.g., `Array<String>`).
+///
+/// The `Array` struct supports parsing both shorthand syntax `[Type]` and full generic form `Array<Type>` of Swift arrays.
+/// This capability is essential for source code analysis where understanding the exact type of array elements is crucial.
+public struct Array: Hashable, Equatable, CustomStringConvertible {
+
+    // MARK: - Supplementary
+
+    public enum DeclType: String, CaseIterable {
+        /// The array was declared using the left/right square brackets. i.e `[String]`
+        case shorthand
+        /// The array was declared using the `Array` keyword with a generic parameter. i.e `Array<String>`
+        case keyword
+    }
+
+    // MARK: - Properties
+
+    /// The element type declared within the array.
+    ///
+    /// For example, in the type `Array<String>` or `[String]` the type will be `.simple("String")`
+    public var elementType: EntityType { resolver.resolveElementType() }
+
+    /// `Bool` whether the result type is optional.
+    ///
+    /// For example, `Result<String, Error>?` has `isOptional` as `true`.
+    public var isOptional: Bool { resolver.resolveIsOptional() }
+    
+    /// The declaration type for the array.
+    /// - See: ``DeclType``
+    public var declType: DeclType
+
+    // MARK: - Properties: Convenience
+
+    private(set) var resolver: any ArraySemanticsResolving
+
+    // MARK: - Lifecycle
+
+    /// Creates a new ``SyntaxSparrow/Result`` instance from a `SimpleTypeIdentifierSyntax` node.
+    ///
+    /// **Note:** Will return `nil` if the `node.firstToken.tokenKind` is not `Result`
+    public init?(_ node: IdentifierTypeSyntax) {
+        guard node.firstToken(viewMode: .fixedUp)?.tokenKind == .identifier("Array") else { return nil }
+        resolver = ArrayIdentifierSemanticsResolver(node: node)
+        declType = .keyword
+    }
+
+    public init(_ node: ArrayTypeSyntax) {
+        resolver = ArrayTypeSemanticsResolver(node: node)
+        declType = .shorthand
+    }
+
+    // MARK: - Equatable
+
+    public static func == (lhs: Array, rhs: Array) -> Bool {
+        return lhs.description == rhs.description
+    }
+
+    // MARK: - Hashable
+
+    public func hash(into hasher: inout Hasher) {
+        return hasher.combine(description.hashValue)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        resolver.node.description.trimmed
+    }
+}

--- a/Sources/SyntaxSparrow/Public/Semantics/Components/ArrayDecl.swift
+++ b/Sources/SyntaxSparrow/Public/Semantics/Components/ArrayDecl.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  Array.swift
 //  
 //
 //  Created by Michael O'Brien on 14/11/2023.
@@ -10,20 +10,20 @@ import SwiftSyntax
 
 /// Represents a Swift `Array` type.
 ///
-/// In Swift, arrays are used to store ordered collections of values. The `Array` struct 
+/// In Swift, arrays are used to store ordered collections of values. The `ArrayDecl` struct
 /// encapsulates an array type from a Swift source file and provides access to the element type.
 ///
 /// The element type is represented as an `EntityType` instance. For example, for the array type `Array<String>`
 /// or `[String]`, the element type will be `.simple("String")`.
 ///
-/// This struct provides functionality to create an `Array` instance from either an `ArrayTypeSyntax` node
+/// This struct provides functionality to create an `ArrayDecl` instance from either an `ArrayTypeSyntax` node
 /// or a `IdentifierTypeSyntax` node with `Array` as the identifier. The struct also distinguishes between
 /// arrays declared using square brackets (e.g., `[String]`) and those declared using the `Array` keyword
 /// with generics (e.g., `Array<String>`).
 ///
-/// The `Array` struct supports parsing both shorthand syntax `[Type]` and full generic form `Array<Type>` of Swift arrays.
+/// The `ArrayDecl` struct supports parsing both shorthand syntax `[Type]` and full generic form `Array<Type>` of Swift arrays.
 /// This capability is essential for source code analysis where understanding the exact type of array elements is crucial.
-public struct Array: Hashable, Equatable, CustomStringConvertible {
+public struct ArrayDecl: Hashable, Equatable, CustomStringConvertible {
 
     // MARK: - Supplementary
 
@@ -43,7 +43,7 @@ public struct Array: Hashable, Equatable, CustomStringConvertible {
 
     /// `Bool` whether the result type is optional.
     ///
-    /// For example, `Result<String, Error>?` has `isOptional` as `true`.
+    /// For example, `Array<String>?` has `isOptional` as `true`.
     public var isOptional: Bool { resolver.resolveIsOptional() }
     
     /// The declaration type for the array.
@@ -56,7 +56,7 @@ public struct Array: Hashable, Equatable, CustomStringConvertible {
 
     // MARK: - Lifecycle
 
-    /// Creates a new ``SyntaxSparrow/Result`` instance from a `SimpleTypeIdentifierSyntax` node.
+    /// Creates a new ``SyntaxSparrow/ArrayDecl`` instance from an `IdentifierTypeSyntax` node.
     ///
     /// **Note:** Will return `nil` if the `node.firstToken.tokenKind` is not `Result`
     public init?(_ node: IdentifierTypeSyntax) {
@@ -72,7 +72,7 @@ public struct Array: Hashable, Equatable, CustomStringConvertible {
 
     // MARK: - Equatable
 
-    public static func == (lhs: Array, rhs: Array) -> Bool {
+    public static func == (lhs: ArrayDecl, rhs: ArrayDecl) -> Bool {
         return lhs.description == rhs.description
     }
 

--- a/Sources/SyntaxSparrow/Public/Semantics/Components/ArrayDecl.swift
+++ b/Sources/SyntaxSparrow/Public/Semantics/Components/ArrayDecl.swift
@@ -48,7 +48,7 @@ public struct ArrayDecl: Hashable, Equatable, CustomStringConvertible {
     
     /// The declaration type for the array.
     /// - See: ``DeclType``
-    public var declType: DeclType
+    public let declType: DeclType
 
     // MARK: - Properties: Convenience
 

--- a/Sources/SyntaxSparrow/Public/Semantics/Components/ArrayDecl.swift
+++ b/Sources/SyntaxSparrow/Public/Semantics/Components/ArrayDecl.swift
@@ -29,9 +29,9 @@ public struct ArrayDecl: Hashable, Equatable, CustomStringConvertible {
 
     public enum DeclType: String, CaseIterable {
         /// The array was declared using the left/right square brackets. i.e `[String]`
-        case shorthand
-        /// The array was declared using the `Array` keyword with a generic parameter. i.e `Array<String>`
-        case keyword
+        case squareBrackets
+        /// The array was declared using the `Array` keyword with generic parameter. i.e `Array<String>`
+        case generic
     }
 
     // MARK: - Properties
@@ -41,7 +41,7 @@ public struct ArrayDecl: Hashable, Equatable, CustomStringConvertible {
     /// For example, in the type `Array<String>` or `[String]` the type will be `.simple("String")`
     public var elementType: EntityType { resolver.resolveElementType() }
 
-    /// `Bool` whether the result type is optional.
+    /// `Bool` whether the array decl is optional.
     ///
     /// For example, `Array<String>?` has `isOptional` as `true`.
     public var isOptional: Bool { resolver.resolveIsOptional() }
@@ -58,16 +58,16 @@ public struct ArrayDecl: Hashable, Equatable, CustomStringConvertible {
 
     /// Creates a new ``SyntaxSparrow/ArrayDecl`` instance from an `IdentifierTypeSyntax` node.
     ///
-    /// **Note:** Will return `nil` if the `node.firstToken.tokenKind` is not `Result`
+    /// **Note:** Will return `nil` if the `node.firstToken.tokenKind` is not `.identifier("Array")`
     public init?(_ node: IdentifierTypeSyntax) {
         guard node.firstToken(viewMode: .fixedUp)?.tokenKind == .identifier("Array") else { return nil }
         resolver = ArrayIdentifierSemanticsResolver(node: node)
-        declType = .keyword
+        declType = .generic
     }
 
     public init(_ node: ArrayTypeSyntax) {
         resolver = ArrayTypeSemanticsResolver(node: node)
-        declType = .shorthand
+        declType = .squareBrackets
     }
 
     // MARK: - Equatable

--- a/Sources/SyntaxSparrow/Public/Semantics/Components/DictionaryDecl.swift
+++ b/Sources/SyntaxSparrow/Public/Semantics/Components/DictionaryDecl.swift
@@ -8,7 +8,7 @@
 import Foundation
 import SwiftSyntax
 
-/// Represents a Swift `Array` type.
+/// Represents a Swift `Dictionary` type.
 ///
 /// In Swift, arrays are used to store ordered collections of values. The `DictionaryDecl` struct
 /// encapsulates an array type from a Swift source file and provides access to the element type.
@@ -23,7 +23,7 @@ import SwiftSyntax
 /// with generics (e.g., `Dictionary<String, String>`).
 ///
 /// The `DictionaryDecl` struct supports parsing both shorthand syntax `[Type: Type]` and full generic
-/// form `Dictionary<Type, Type>` of Swift arrays.
+/// form `Dictionary<Type, Type>` of Swift dictionaries.
 /// This capability is essential for source code analysis where understanding the exact type of array elements is crucial.
 public struct DictionaryDecl: Hashable, Equatable, CustomStringConvertible {
 
@@ -41,7 +41,7 @@ public struct DictionaryDecl: Hashable, Equatable, CustomStringConvertible {
     /// The key type declared within the dictionary.
     ///
     /// For example, in the type `Dictionary<String, String>` or `[String: String]` the key type will be `.simple("String")`
-    public var keyType: EntityType { resolver.resolveElementType() }
+    public var keyType: EntityType { resolver.resolveKeyType() }
 
     /// The value type declared within the dictionary.
     ///
@@ -59,7 +59,7 @@ public struct DictionaryDecl: Hashable, Equatable, CustomStringConvertible {
 
     // MARK: - Properties: Convenience
 
-    private(set) var resolver: any ArraySemanticsResolving
+    private(set) var resolver: any DictionarySemanticsResolving
 
     // MARK: - Lifecycle
 

--- a/Sources/SyntaxSparrow/Public/Semantics/Components/DictionaryDecl.swift
+++ b/Sources/SyntaxSparrow/Public/Semantics/Components/DictionaryDecl.swift
@@ -1,6 +1,6 @@
 //
-//  Array.swift
-//  
+//  DictionaryDecl.swift
+//
 //
 //  Created by Michael O'Brien on 14/11/2023.
 //
@@ -10,8 +10,8 @@ import SwiftSyntax
 
 /// Represents a Swift `Dictionary` type.
 ///
-/// In Swift, arrays are used to store ordered collections of values. The `DictionaryDecl` struct
-/// encapsulates an array type from a Swift source file and provides access to the element type.
+/// In Swift, dictionaries are used to store values against a hashable key. The `DictionaryDecl` struct
+/// encapsulates an dictionary type from a Swift source file and provides access to the element type.
 ///
 /// The element type is represented as an `EntityType` instance. For example, for the dictionary
 /// type `Dictionary<String, Int>` or `[String: Int]`, the key type would be `.simple("String")` and the
@@ -19,21 +19,21 @@ import SwiftSyntax
 ///
 /// This struct provides functionality to create an `DictionaryDecl` instance from either an `DictionaryTypeSyntax` node
 /// or a `IdentifierTypeSyntax` node with `Dictionary` as the identifier. The struct also distinguishes between
-/// arrays declared using square brackets (e.g., `[String: String]`) and those declared using the `Dictionary` keyword
+/// dictionaries declared using square brackets (e.g., `[String: String]`) and those declared using the `Dictionary` keyword
 /// with generics (e.g., `Dictionary<String, String>`).
 ///
 /// The `DictionaryDecl` struct supports parsing both shorthand syntax `[Type: Type]` and full generic
 /// form `Dictionary<Type, Type>` of Swift dictionaries.
-/// This capability is essential for source code analysis where understanding the exact type of array elements is crucial.
+/// This capability is essential for source code analysis where understanding the exact type of dictionary key and value types is crucial.
 public struct DictionaryDecl: Hashable, Equatable, CustomStringConvertible {
 
     // MARK: - Supplementary
 
     public enum DeclType: String, CaseIterable {
-        /// The array was declared using the left/right square brackets. i.e `[String]`
-        case shorthand
-        /// The array was declared using the `Array` keyword with a generic parameter. i.e `Array<String>`
-        case keyword
+        /// The dictionary was declared using the left/right square brackets. i.e `[String: String]`
+        case squareBrackets
+        /// The dictionary was declared using the `Dictionary` keyword with generic parameters. i.e `Dictionary<String, String>`
+        case generics
     }
 
     // MARK: - Properties
@@ -53,7 +53,7 @@ public struct DictionaryDecl: Hashable, Equatable, CustomStringConvertible {
     /// For example, `Dictionary<String, String>?` or `[String: String]?` has `isOptional` as `true`.
     public var isOptional: Bool { resolver.resolveIsOptional() }
     
-    /// The declaration type for the array.
+    /// The declaration type for the dictionary.
     /// - See: ``DeclType``
     public var declType: DeclType
 
@@ -69,12 +69,12 @@ public struct DictionaryDecl: Hashable, Equatable, CustomStringConvertible {
     public init?(_ node: IdentifierTypeSyntax) {
         guard node.firstToken(viewMode: .fixedUp)?.tokenKind == .identifier("Dictionary") else { return nil }
         resolver = DictionaryIdentifierSemanticsResolver(node: node)
-        declType = .keyword
+        declType = .generics
     }
 
     public init(_ node: DictionaryTypeSyntax) {
         resolver = DictionaryTypeSemanticsResolver(node: node)
-        declType = .shorthand
+        declType = .squareBrackets
     }
 
     // MARK: - Equatable

--- a/Sources/SyntaxSparrow/Public/Semantics/Components/DictionaryDecl.swift
+++ b/Sources/SyntaxSparrow/Public/Semantics/Components/DictionaryDecl.swift
@@ -55,7 +55,7 @@ public struct DictionaryDecl: Hashable, Equatable, CustomStringConvertible {
     
     /// The declaration type for the dictionary.
     /// - See: ``DeclType``
-    public var declType: DeclType
+    public let declType: DeclType
 
     // MARK: - Properties: Convenience
 

--- a/Sources/SyntaxSparrow/Public/Semantics/Components/DictionaryDecl.swift
+++ b/Sources/SyntaxSparrow/Public/Semantics/Components/DictionaryDecl.swift
@@ -1,0 +1,97 @@
+//
+//  Array.swift
+//  
+//
+//  Created by Michael O'Brien on 14/11/2023.
+//
+
+import Foundation
+import SwiftSyntax
+
+/// Represents a Swift `Array` type.
+///
+/// In Swift, arrays are used to store ordered collections of values. The `DictionaryDecl` struct
+/// encapsulates an array type from a Swift source file and provides access to the element type.
+///
+/// The element type is represented as an `EntityType` instance. For example, for the dictionary
+/// type `Dictionary<String, Int>` or `[String: Int]`, the key type would be `.simple("String")` and the
+/// element type would be `.simple("Int")`.
+///
+/// This struct provides functionality to create an `DictionaryDecl` instance from either an `DictionaryTypeSyntax` node
+/// or a `IdentifierTypeSyntax` node with `Dictionary` as the identifier. The struct also distinguishes between
+/// arrays declared using square brackets (e.g., `[String: String]`) and those declared using the `Dictionary` keyword
+/// with generics (e.g., `Dictionary<String, String>`).
+///
+/// The `DictionaryDecl` struct supports parsing both shorthand syntax `[Type: Type]` and full generic
+/// form `Dictionary<Type, Type>` of Swift arrays.
+/// This capability is essential for source code analysis where understanding the exact type of array elements is crucial.
+public struct DictionaryDecl: Hashable, Equatable, CustomStringConvertible {
+
+    // MARK: - Supplementary
+
+    public enum DeclType: String, CaseIterable {
+        /// The array was declared using the left/right square brackets. i.e `[String]`
+        case shorthand
+        /// The array was declared using the `Array` keyword with a generic parameter. i.e `Array<String>`
+        case keyword
+    }
+
+    // MARK: - Properties
+
+    /// The key type declared within the dictionary.
+    ///
+    /// For example, in the type `Dictionary<String, String>` or `[String: String]` the key type will be `.simple("String")`
+    public var keyType: EntityType { resolver.resolveElementType() }
+
+    /// The value type declared within the dictionary.
+    ///
+    /// For example, in the type `Dictionary<String, String>` or `[String: String]` the element type will be `.simple("String")`
+    public var valueType: EntityType { resolver.resolveElementType() }
+
+    /// `Bool` whether the result type is optional.
+    ///
+    /// For example, `Dictionary<String, String>?` or `[String: String]?` has `isOptional` as `true`.
+    public var isOptional: Bool { resolver.resolveIsOptional() }
+    
+    /// The declaration type for the array.
+    /// - See: ``DeclType``
+    public var declType: DeclType
+
+    // MARK: - Properties: Convenience
+
+    private(set) var resolver: any ArraySemanticsResolving
+
+    // MARK: - Lifecycle
+
+    /// Creates a new ``SyntaxSparrow/DictionaryDecl`` instance from an `IdentifierTypeSyntax` node.
+    ///
+    /// **Note:** Will return `nil` if the `node.firstToken.tokenKind` is not `Result`
+    public init?(_ node: IdentifierTypeSyntax) {
+        guard node.firstToken(viewMode: .fixedUp)?.tokenKind == .identifier("Dictionary") else { return nil }
+        resolver = DictionaryIdentifierSemanticsResolver(node: node)
+        declType = .keyword
+    }
+
+    public init(_ node: DictionaryTypeSyntax) {
+        resolver = DictionaryTypeSemanticsResolver(node: node)
+        declType = .shorthand
+    }
+
+    // MARK: - Equatable
+
+    public static func == (lhs: DictionaryDecl, rhs: DictionaryDecl) -> Bool {
+        return lhs.description == rhs.description
+    }
+
+    // MARK: - Hashable
+
+    public func hash(into hasher: inout Hasher) {
+        return hasher.combine(description.hashValue)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        resolver.node.description.trimmed
+    }
+}

--- a/Sources/SyntaxSparrow/Public/Semantics/Components/EntityType.swift
+++ b/Sources/SyntaxSparrow/Public/Semantics/Components/EntityType.swift
@@ -19,7 +19,7 @@ public enum EntityType: Equatable, Hashable, CustomStringConvertible {
     /// `.simple("CVarArg...")`
     case simple(_ type: String)
 
-    /// A `array` type is used when a parameter's type is a valid ``SyntaxSparrow/Array`` type.
+    /// A `array` type is used when a parameter's type is a valid ``SyntaxSparrow/ArrayDecl`` type.
     ///
     /// The `Array` supports `isOptional` to derive if the type has the optional/`?` suffix.
     ///
@@ -28,8 +28,32 @@ public enum EntityType: Equatable, Hashable, CustomStringConvertible {
     /// func example(names: [String])
     /// func example(names: Array<String>)
     /// ```
-    /// would have a type of `.array(Array)` where the ``SyntaxSparrow//Array`` has the `elementType` of `.simple("String")`.
-    case array(_ array: Array)
+    /// would have a type of `.array(Array)` where the ``SyntaxSparrow/ArrayDecl`` has the `elementType` of `.simple("String")`.
+    case array(_ array: ArrayDecl)
+
+    /// A `array` type is used when a parameter's type is a valid ``SyntaxSparrow/SetDecl`` type.
+    ///
+    /// The `Set` supports `isOptional` to derive if the type has the optional/`?` suffix.
+    ///
+    /// For example,
+    /// ```swift
+    /// func example(names: Set<String>)
+    /// ```
+    /// would have a type of `.set(Set)` where the ``SyntaxSparrow/SetDecl`` has the `elementType` of `.simple("String")`.
+    case set(_ set: SetDecl)
+
+    /// A `array` type is used when a parameter's type is a valid ``SyntaxSparrow/DictionaryDecl`` type.
+    ///
+    /// The `Set` supports `isOptional` to derive if the type has the optional/`?` suffix.
+    ///
+    /// For example,
+    /// ```swift
+    /// func example(names: [String: Int])
+    /// func example(names: Dictionary<String, Int>)
+    /// ```
+    /// would have a type of `.dictionary(DictionaryDecl)` where the ``SyntaxSparrow/DictionaryDecl`` has
+    /// the `keyType` of `.simple("String")` and the `.elementType` of `.simple("Int")`.
+    case dictionary(_ dictionary: DictionaryDecl)
 
     /// A `tuple` type is used when a parameter's type is a valid ``SyntaxSparrow/Tuple`` type.
     ///
@@ -91,6 +115,10 @@ public enum EntityType: Equatable, Hashable, CustomStringConvertible {
             return type
         case let .array(array):
             return array.description
+        case let .set(set):
+            return set.description
+        case let .dictionary(dictionary):
+            return dictionary.description
         case let .tuple(tuple):
             return tuple.description
         case let .closure(closure):

--- a/Sources/SyntaxSparrow/Public/Semantics/Components/EntityType.swift
+++ b/Sources/SyntaxSparrow/Public/Semantics/Components/EntityType.swift
@@ -19,6 +19,18 @@ public enum EntityType: Equatable, Hashable, CustomStringConvertible {
     /// `.simple("CVarArg...")`
     case simple(_ type: String)
 
+    /// A `array` type is used when a parameter's type is a valid ``SyntaxSparrow/Array`` type.
+    ///
+    /// The `Array` supports `isOptional` to derive if the type has the optional/`?` suffix.
+    ///
+    /// For example,
+    /// ```swift
+    /// func example(names: [String])
+    /// func example(names: Array<String>)
+    /// ```
+    /// would have a type of `.array(Array)` where the ``SyntaxSparrow//Array`` has the `elementType` of `.simple("String")`.
+    case array(_ array: Array)
+
     /// A `tuple` type is used when a parameter's type is a valid ``SyntaxSparrow/Tuple`` type.
     ///
     /// The `Tuple` type supports `isOptional` to derive if the type has the optional/`?` suffix.
@@ -77,6 +89,8 @@ public enum EntityType: Equatable, Hashable, CustomStringConvertible {
         switch self {
         case let .simple(type):
             return type
+        case let .array(array):
+            return array.description
         case let .tuple(tuple):
             return tuple.description
         case let .closure(closure):

--- a/Sources/SyntaxSparrow/Public/Semantics/Components/Result.swift
+++ b/Sources/SyntaxSparrow/Public/Semantics/Components/Result.swift
@@ -43,7 +43,7 @@ public struct Result: Hashable, Equatable, CustomStringConvertible {
 
     // MARK: - Lifecycle
 
-    /// Creates a new ``SyntaxSparrow/Result`` instance from a `SimpleTypeIdentifierSyntax` node.
+    /// Creates a new ``SyntaxSparrow/Result`` instance from a `IdentifierTypeSyntax` node.
     ///
     /// **Note:** Will return `nil` if the `node.firstToken.tokenKind` is not `Result`
     public init?(_ node: IdentifierTypeSyntax) {

--- a/Sources/SyntaxSparrow/Public/Semantics/Components/SetDecl.swift
+++ b/Sources/SyntaxSparrow/Public/Semantics/Components/SetDecl.swift
@@ -1,0 +1,68 @@
+//
+//  File.swift
+//  
+//
+//  Created by Michael O'Brien on 14/11/2023.
+//
+
+import Foundation
+import SwiftSyntax
+
+/// Represents a Swift `Set` type.
+///
+/// In Swift, sets are used to store unique collections of values. The `SetDecl` struct
+/// encapsulates an set type from a Swift source file and provides access to the element type.
+///
+/// The element type is represented as an `EntityType` instance. For example, for the set type `Set<String>`,
+/// the element type will be `.simple("String")`.
+///
+/// This struct provides functionality to create an `SetDecl` instance from an `ArrayTypeSyntax`
+/// `IdentifierTypeSyntax` node with `Set` as the identifier.
+///
+/// This capability is essential for source code analysis where understanding the exact type of set element is crucial.
+public struct SetDecl: Hashable, Equatable, CustomStringConvertible {
+
+    // MARK: - Properties
+
+    /// The element type declared within the set.
+    ///
+    /// For example, in the type `Set<String>`, the `entityType` will be `.simple("String")`
+    public var elementType: EntityType { resolver.resolveElementType() }
+
+    /// `Bool` whether the result type is optional.
+    ///
+    /// For example, `Set<String>?` has `isOptional` as `true`.
+    public var isOptional: Bool { resolver.resolveIsOptional() }
+
+    // MARK: - Properties: Convenience
+
+    private(set) var resolver: SetSemanticsResolver
+
+    // MARK: - Lifecycle
+
+    /// Creates a new ``SyntaxSparrow/SetDecl`` instance from a `IdentifierTypeSyntax` node.
+    ///
+    /// **Note:** Will return `nil` if the `node.firstToken.tokenKind` is not `Result`
+    public init?(_ node: IdentifierTypeSyntax) {
+        guard node.firstToken(viewMode: .fixedUp)?.tokenKind == .identifier("Set") else { return nil }
+        resolver = SetSemanticsResolver(node: node)
+    }
+
+    // MARK: - Equatable
+
+    public static func == (lhs: SetDecl, rhs: SetDecl) -> Bool {
+        return lhs.description == rhs.description
+    }
+
+    // MARK: - Hashable
+
+    public func hash(into hasher: inout Hasher) {
+        return hasher.combine(description.hashValue)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        resolver.node.description.trimmed
+    }
+}

--- a/Tests/SyntaxSparrowTests/Declarations/EnumerationTests.swift
+++ b/Tests/SyntaxSparrowTests/Declarations/EnumerationTests.swift
@@ -773,8 +773,15 @@ final class DeinitializerTests: XCTestCase {
         XCTAssertFalse(enumCase.associatedValues[0].isOptional)
         XCTAssertTrue(enumCase.associatedValues[0].isInOut)
         XCTAssertEqual(enumCase.associatedValues[0].rawType, "inout [String]")
-        XCTAssertEqual(enumCase.associatedValues[0].type, .simple("[String]"))
         XCTAssertNil(enumCase.associatedValues[0].defaultArgument)
         XCTAssertEqual(enumCase.associatedValues[0].description, "names: inout [String]")
+
+        if case let EntityType.array(array) = enumCase.associatedValues[0].type {
+            XCTAssertEqual(array.declType, .shorthand)
+            XCTAssertFalse(array.isOptional)
+            XCTAssertEqual(array.elementType, .simple("String"))
+        } else {
+            XCTFail("function.signature.input[0] type should be Array")
+        }
     }
 }

--- a/Tests/SyntaxSparrowTests/Declarations/EnumerationTests.swift
+++ b/Tests/SyntaxSparrowTests/Declarations/EnumerationTests.swift
@@ -777,7 +777,7 @@ final class DeinitializerTests: XCTestCase {
         XCTAssertEqual(enumCase.associatedValues[0].description, "names: inout [String]")
 
         if case let EntityType.array(array) = enumCase.associatedValues[0].type {
-            XCTAssertEqual(array.declType, .shorthand)
+            XCTAssertEqual(array.declType, .squareBrackets)
             XCTAssertFalse(array.isOptional)
             XCTAssertEqual(array.elementType, .simple("String"))
         } else {

--- a/Tests/SyntaxSparrowTests/Declarations/FunctionTests.swift
+++ b/Tests/SyntaxSparrowTests/Declarations/FunctionTests.swift
@@ -256,7 +256,7 @@ final class FunctionTests: XCTestCase {
         XCTAssertEqual(function.signature.input[1].type, .simple("C2"))
         XCTAssertNil(function.signature.effectSpecifiers?.throwsSpecifier)
         if let outputType = function.signature.output, case let EntityType.array(array) = outputType {
-            XCTAssertEqual(array.declType, .shorthand)
+            XCTAssertEqual(array.declType, .squareBrackets)
             XCTAssertFalse(array.isOptional)
             XCTAssertEqual(array.elementType, .simple("C1.Element"))
         } else {
@@ -776,7 +776,7 @@ final class FunctionTests: XCTestCase {
         XCTAssertNil(function.signature.input[0].defaultArgument)
         XCTAssertEqual(function.signature.input[0].description, "names: inout [String]")
         if case let EntityType.array(array) = function.signature.input[0].type {
-            XCTAssertEqual(array.declType, .shorthand)
+            XCTAssertEqual(array.declType, .squareBrackets)
             XCTAssertFalse(array.isOptional)
             XCTAssertEqual(array.elementType, .simple("String"))
         } else {
@@ -822,7 +822,7 @@ final class FunctionTests: XCTestCase {
         XCTAssertEqual(function.signature.input.count, 1)
 
         if case let EntityType.array(array) = function.signature.input[0].type {
-            XCTAssertEqual(array.declType, .shorthand)
+            XCTAssertEqual(array.declType, .squareBrackets)
             XCTAssertTrue(array.isOptional)
             if case let EntityType.tuple(tuple) = array.elementType {
                 XCTAssertEqual(tuple.elements.count, 2)
@@ -845,7 +845,7 @@ final class FunctionTests: XCTestCase {
         XCTAssertEqual(function.signature.input.count, 1)
 
         if case let EntityType.array(array) = function.signature.input[0].type {
-            XCTAssertEqual(array.declType, .keyword)
+            XCTAssertEqual(array.declType, .generic)
             XCTAssertFalse(array.isOptional)
             XCTAssertEqual(array.elementType, .simple("String"))
         } else {
@@ -878,7 +878,7 @@ final class FunctionTests: XCTestCase {
         if case let EntityType.dictionary(dict) = function.signature.input[0].type {
             XCTAssertTrue(dict.isOptional)
             XCTAssertEqual(dict.keyType, .simple("String"))
-            XCTAssertEqual(dict.declType, .shorthand)
+            XCTAssertEqual(dict.declType, .squareBrackets)
             if case let EntityType.tuple(tuple) = dict.valueType {
                 XCTAssertEqual(tuple.elements.count, 2)
                 XCTAssertEqual(tuple.elements[0].name, "name")
@@ -902,7 +902,7 @@ final class FunctionTests: XCTestCase {
         if case let EntityType.dictionary(dict) = function.signature.input[0].type {
             XCTAssertTrue(dict.isOptional)
             XCTAssertEqual(dict.keyType, .simple("String"))
-            XCTAssertEqual(dict.declType, .keyword)
+            XCTAssertEqual(dict.declType, .generics)
             if case let EntityType.tuple(tuple) = dict.valueType {
                 XCTAssertEqual(tuple.elements.count, 2)
                 XCTAssertEqual(tuple.elements[0].name, "name")

--- a/Tests/SyntaxSparrowTests/Declarations/FunctionTests.swift
+++ b/Tests/SyntaxSparrowTests/Declarations/FunctionTests.swift
@@ -322,12 +322,15 @@ final class FunctionTests: XCTestCase {
         func asyncAwaitMethodThrowingReturning() throws async -> String {}
         func arrayShorthand(persons: [(name: String, age: Int?)]?) {}
         func arrayIdentifier(names: Array<String>) {}
+        func setIdentifier(names: Set<String>) {}
+        func dictionaryShorthand(persons: [String: (name: String, age: Int?)]?) {}
+        func dictionaryIdentifier(names: Dictionary<String, (name: String, age: Int?)>?) {}
         """#
         instanceUnderTest.updateToSource(source)
         XCTAssertTrue(instanceUnderTest.isStale)
         instanceUnderTest.collectChildren()
         XCTAssertFalse(instanceUnderTest.isStale)
-        XCTAssertEqual(instanceUnderTest.functions.count, 23)
+        XCTAssertEqual(instanceUnderTest.functions.count, 26)
 
         // No Parameters
         // func noParameters() throws {}
@@ -847,6 +850,69 @@ final class FunctionTests: XCTestCase {
             XCTAssertEqual(array.elementType, .simple("String"))
         } else {
             XCTFail("function.signature.input[0] type should be Array")
+        }
+
+        // func setIdentifier(names: Set<String>) {}
+        function = instanceUnderTest.functions[23]
+        XCTAssertEqual(function.keyword, "func")
+        XCTAssertEqual(function.identifier, "setIdentifier")
+        XCTAssertNil(function.signature.effectSpecifiers?.throwsSpecifier)
+        XCTAssertNil(function.signature.effectSpecifiers?.asyncSpecifier)
+        XCTAssertEqual(function.signature.input.count, 1)
+
+        if case let EntityType.set(set) = function.signature.input[0].type {
+            XCTAssertFalse(set.isOptional)
+            XCTAssertEqual(set.elementType, .simple("String"))
+        } else {
+            XCTFail("function.signature.input[0] type should be Set")
+        }
+
+        // func dictionaryShorthand(persons: [String: (name: String, age: Int?)]?) {}
+        function = instanceUnderTest.functions[24]
+        XCTAssertEqual(function.keyword, "func")
+        XCTAssertEqual(function.identifier, "dictionaryShorthand")
+        XCTAssertNil(function.signature.effectSpecifiers?.throwsSpecifier)
+        XCTAssertNil(function.signature.effectSpecifiers?.asyncSpecifier)
+        XCTAssertEqual(function.signature.input.count, 1)
+
+        if case let EntityType.dictionary(dict) = function.signature.input[0].type {
+            XCTAssertTrue(dict.isOptional)
+            XCTAssertEqual(dict.keyType, .simple("String"))
+            XCTAssertEqual(dict.declType, .shorthand)
+            if case let EntityType.tuple(tuple) = dict.valueType {
+                XCTAssertEqual(tuple.elements.count, 2)
+                XCTAssertEqual(tuple.elements[0].name, "name")
+                XCTAssertEqual(tuple.elements[0].type, .simple("String"))
+                XCTAssertEqual(tuple.elements[1].name, "age")
+                XCTAssertEqual(tuple.elements[1].type, .simple("Int?"))
+                XCTAssertFalse(tuple.isOptional)
+            }
+        } else {
+            XCTFail("function.signature.input[0] type should be Dictionary")
+        }
+
+        // func dictionaryIdentifier(names: Dictionary<String, (name: String, age: Int?)>?) {}
+        function = instanceUnderTest.functions[25]
+        XCTAssertEqual(function.keyword, "func")
+        XCTAssertEqual(function.identifier, "dictionaryIdentifier")
+        XCTAssertNil(function.signature.effectSpecifiers?.throwsSpecifier)
+        XCTAssertNil(function.signature.effectSpecifiers?.asyncSpecifier)
+        XCTAssertEqual(function.signature.input.count, 1)
+
+        if case let EntityType.dictionary(dict) = function.signature.input[0].type {
+            XCTAssertTrue(dict.isOptional)
+            XCTAssertEqual(dict.keyType, .simple("String"))
+            XCTAssertEqual(dict.declType, .keyword)
+            if case let EntityType.tuple(tuple) = dict.valueType {
+                XCTAssertEqual(tuple.elements.count, 2)
+                XCTAssertEqual(tuple.elements[0].name, "name")
+                XCTAssertEqual(tuple.elements[0].type, .simple("String"))
+                XCTAssertEqual(tuple.elements[1].name, "age")
+                XCTAssertEqual(tuple.elements[1].type, .simple("Int?"))
+                XCTAssertFalse(tuple.isOptional)
+            }
+        } else {
+            XCTFail("function.signature.input[0] type should be Dictionary")
         }
     }
 

--- a/Tests/SyntaxSparrowTests/Declarations/FunctionTests.swift
+++ b/Tests/SyntaxSparrowTests/Declarations/FunctionTests.swift
@@ -255,7 +255,14 @@ final class FunctionTests: XCTestCase {
         XCTAssertEqual(function.signature.input[1].secondName, "rhs")
         XCTAssertEqual(function.signature.input[1].type, .simple("C2"))
         XCTAssertNil(function.signature.effectSpecifiers?.throwsSpecifier)
-        XCTAssertEqual(function.signature.output, .simple("[C1.Element]"))
+        if let outputType = function.signature.output, case let EntityType.array(array) = outputType {
+            XCTAssertEqual(array.declType, .shorthand)
+            XCTAssertFalse(array.isOptional)
+            XCTAssertEqual(array.elementType, .simple("C1.Element"))
+        } else {
+            XCTFail("function.signature.input[0] type should be Array")
+        }
+
         AssertSourceDetailsEquals(
             getSourceLocation(for: function, from: instanceUnderTest),
             start: (1, 0, 75),
@@ -313,12 +320,14 @@ final class FunctionTests: XCTestCase {
         func asyncAwaitMethod() async {}
         func asyncAwaitMethodThrowing() throws async {}
         func asyncAwaitMethodThrowingReturning() throws async -> String {}
+        func arrayShorthand(persons: [(name: String, age: Int?)]?) {}
+        func arrayIdentifier(names: Array<String>) {}
         """#
         instanceUnderTest.updateToSource(source)
         XCTAssertTrue(instanceUnderTest.isStale)
         instanceUnderTest.collectChildren()
         XCTAssertFalse(instanceUnderTest.isStale)
-        XCTAssertEqual(instanceUnderTest.functions.count, 21)
+        XCTAssertEqual(instanceUnderTest.functions.count, 23)
 
         // No Parameters
         // func noParameters() throws {}
@@ -761,9 +770,15 @@ final class FunctionTests: XCTestCase {
         XCTAssertFalse(function.signature.input[0].isOptional)
         XCTAssertTrue(function.signature.input[0].isInOut)
         XCTAssertEqual(function.signature.input[0].rawType, "inout [String]")
-        XCTAssertEqual(function.signature.input[0].type, .simple("[String]"))
         XCTAssertNil(function.signature.input[0].defaultArgument)
         XCTAssertEqual(function.signature.input[0].description, "names: inout [String]")
+        if case let EntityType.array(array) = function.signature.input[0].type {
+            XCTAssertEqual(array.declType, .shorthand)
+            XCTAssertFalse(array.isOptional)
+            XCTAssertEqual(array.elementType, .simple("String"))
+        } else {
+            XCTFail("function.signature.input[0] type should be Array")
+        }
 
         // async function
         // func asyncAwaitMethod() async {}
@@ -794,6 +809,45 @@ final class FunctionTests: XCTestCase {
         XCTAssertEqual(function.signature.effectSpecifiers?.asyncSpecifier, "async")
         XCTAssertEqual(function.signature.output, .simple("String"))
         XCTAssertEqual(function.signature.input.count, 0)
+
+        // func arrayShorthand(persons: [(name: String, age: Int?)]?) {}
+        function = instanceUnderTest.functions[21]
+        XCTAssertEqual(function.keyword, "func")
+        XCTAssertEqual(function.identifier, "arrayShorthand")
+        XCTAssertNil(function.signature.effectSpecifiers?.throwsSpecifier)
+        XCTAssertNil(function.signature.effectSpecifiers?.asyncSpecifier)
+        XCTAssertEqual(function.signature.input.count, 1)
+
+        if case let EntityType.array(array) = function.signature.input[0].type {
+            XCTAssertEqual(array.declType, .shorthand)
+            XCTAssertTrue(array.isOptional)
+            if case let EntityType.tuple(tuple) = array.elementType {
+                XCTAssertEqual(tuple.elements.count, 2)
+                XCTAssertEqual(tuple.elements[0].name, "name")
+                XCTAssertEqual(tuple.elements[0].type, .simple("String"))
+                XCTAssertEqual(tuple.elements[1].name, "age")
+                XCTAssertEqual(tuple.elements[1].type, .simple("Int?"))
+                XCTAssertFalse(tuple.isOptional)
+            }
+        } else {
+            XCTFail("function.signature.input[0] type should be Array")
+        }
+
+        // func arrayIdentifier(names: Array<String>) {}
+        function = instanceUnderTest.functions[22]
+        XCTAssertEqual(function.keyword, "func")
+        XCTAssertEqual(function.identifier, "arrayIdentifier")
+        XCTAssertNil(function.signature.effectSpecifiers?.throwsSpecifier)
+        XCTAssertNil(function.signature.effectSpecifiers?.asyncSpecifier)
+        XCTAssertEqual(function.signature.input.count, 1)
+
+        if case let EntityType.array(array) = function.signature.input[0].type {
+            XCTAssertEqual(array.declType, .keyword)
+            XCTAssertFalse(array.isOptional)
+            XCTAssertEqual(array.elementType, .simple("String"))
+        } else {
+            XCTFail("function.signature.input[0] type should be Array")
+        }
     }
 
     func test_function_outputIsOptional_willResolveExpectedTypes() throws {

--- a/Tests/SyntaxSparrowTests/Declarations/TypealiasTests.swift
+++ b/Tests/SyntaxSparrowTests/Declarations/TypealiasTests.swift
@@ -72,7 +72,7 @@ final class TypealiasTests: XCTestCase {
         XCTAssertEqual(typealiasDecl.genericParameters[0].type, "Equatable")
         XCTAssertEqual(typealiasDecl.genericRequirements.count, 0)
         if case let EntityType.array(array) = typealiasDecl.initializedType {
-            XCTAssertEqual(array.declType, .keyword)
+            XCTAssertEqual(array.declType, .generic)
             XCTAssertFalse(array.isOptional)
             XCTAssertEqual(array.elementType, .simple("T"))
         } else {

--- a/Tests/SyntaxSparrowTests/Declarations/TypealiasTests.swift
+++ b/Tests/SyntaxSparrowTests/Declarations/TypealiasTests.swift
@@ -67,11 +67,18 @@ final class TypealiasTests: XCTestCase {
         XCTAssertEqual(typealiasDecl.modifiers.count, 0)
         XCTAssertEqual(typealiasDecl.keyword, "typealias")
         XCTAssertEqual(typealiasDecl.name, "EquatableArray")
-        XCTAssertEqual(typealiasDecl.initializedType, .simple("Array<T>"))
         XCTAssertEqual(typealiasDecl.genericParameters.count, 1)
         XCTAssertEqual(typealiasDecl.genericParameters[0].name, "T")
         XCTAssertEqual(typealiasDecl.genericParameters[0].type, "Equatable")
         XCTAssertEqual(typealiasDecl.genericRequirements.count, 0)
+        if case let EntityType.array(array) = typealiasDecl.initializedType {
+            XCTAssertEqual(array.declType, .keyword)
+            XCTAssertFalse(array.isOptional)
+            XCTAssertEqual(array.elementType, .simple("T"))
+        } else {
+            XCTFail("function.signature.input[0] type should be Array")
+        }
+
         AssertSourceDetailsEquals(
             getSourceLocation(for: typealiasDecl, from: instanceUnderTest),
             start: (0, 0, 0),

--- a/Tests/SyntaxSparrowTests/Supporting Types/EntityTypeTests.swift
+++ b/Tests/SyntaxSparrowTests/Supporting Types/EntityTypeTests.swift
@@ -23,5 +23,408 @@ final class EntityTypeTests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
 
-    // MARK: - Tests
+    // MARK: - Tests: Array
+
+    func test_array_inFunctionParameter_willReturnExpectedTypes() throws {
+        let source = """
+        func arrayShorthand(persons: [(name: String, age: Int?)]?) {}
+        func arrayIdentifier(names: Array<String>) {}
+        """
+        instanceUnderTest.updateToSource(source)
+        XCTAssertTrue(instanceUnderTest.isStale)
+        instanceUnderTest.collectChildren()
+        XCTAssertFalse(instanceUnderTest.isStale)
+        XCTAssertEqual(instanceUnderTest.functions.count, 2)
+
+        var function = instanceUnderTest.functions[0]
+        XCTAssertEqual(function.keyword, "func")
+        XCTAssertEqual(function.identifier, "arrayShorthand")
+        XCTAssertNil(function.signature.effectSpecifiers?.throwsSpecifier)
+        XCTAssertNil(function.signature.effectSpecifiers?.asyncSpecifier)
+        XCTAssertEqual(function.signature.input.count, 1)
+
+        if case let EntityType.array(array) = function.signature.input[0].type {
+            XCTAssertEqual(array.declType, .shorthand)
+            XCTAssertTrue(array.isOptional)
+            if case let EntityType.tuple(tuple) = array.elementType {
+                XCTAssertEqual(tuple.elements.count, 2)
+                XCTAssertEqual(tuple.elements[0].name, "name")
+                XCTAssertEqual(tuple.elements[0].type, .simple("String"))
+                XCTAssertEqual(tuple.elements[1].name, "age")
+                XCTAssertEqual(tuple.elements[1].type, .simple("Int?"))
+                XCTAssertFalse(tuple.isOptional)
+            }
+        } else {
+            XCTFail("function.signature.input[0] type should be Array")
+        }
+
+        // func arrayIdentifier(names: Array<String>) {}
+        function = instanceUnderTest.functions[1]
+        XCTAssertEqual(function.keyword, "func")
+        XCTAssertEqual(function.identifier, "arrayIdentifier")
+        XCTAssertNil(function.signature.effectSpecifiers?.throwsSpecifier)
+        XCTAssertNil(function.signature.effectSpecifiers?.asyncSpecifier)
+        XCTAssertEqual(function.signature.input.count, 1)
+
+        if case let EntityType.array(array) = function.signature.input[0].type {
+            XCTAssertEqual(array.declType, .keyword)
+            XCTAssertFalse(array.isOptional)
+            XCTAssertEqual(array.elementType, .simple("String"))
+        } else {
+            XCTFail("function.signature.input[0] type should be Array")
+        }
+    }
+
+    func test_array_asVariable_willReturnExpectedTypes() throws {
+        let source = """
+        var arrayShorthand: [(name: String, age: Int?)]?
+        var arrayIdentifier: Array<String>)
+        """
+        instanceUnderTest.updateToSource(source)
+        XCTAssertTrue(instanceUnderTest.isStale)
+        instanceUnderTest.collectChildren()
+        XCTAssertFalse(instanceUnderTest.isStale)
+        XCTAssertEqual(instanceUnderTest.variables.count, 2)
+
+        // var arrayShorthand: [(name: String, age: Int?)]?
+        var target = instanceUnderTest.variables[0]
+        XCTAssertEqual(target.keyword, "var")
+        XCTAssertEqual(target.name, "arrayShorthand")
+        XCTAssertTrue(target.isOptional)
+
+        if case let EntityType.array(array) = target.type {
+            XCTAssertEqual(array.declType, .shorthand)
+            XCTAssertTrue(array.isOptional)
+            if case let EntityType.tuple(tuple) = array.elementType {
+                XCTAssertEqual(tuple.elements.count, 2)
+                XCTAssertEqual(tuple.elements[0].name, "name")
+                XCTAssertEqual(tuple.elements[0].type, .simple("String"))
+                XCTAssertEqual(tuple.elements[1].name, "age")
+                XCTAssertEqual(tuple.elements[1].type, .simple("Int?"))
+                XCTAssertFalse(tuple.isOptional)
+            }
+        } else {
+            XCTFail("variable type should be Array")
+        }
+
+        // var arrayIdentifier: Array<String>)
+        target = instanceUnderTest.variables[1]
+        XCTAssertEqual(target.keyword, "var")
+        XCTAssertEqual(target.name, "arrayIdentifier")
+        XCTAssertFalse(target.isOptional)
+
+        if case let EntityType.array(array) = target.type {
+            XCTAssertEqual(array.declType, .keyword)
+            XCTAssertFalse(array.isOptional)
+            XCTAssertEqual(array.elementType, .simple("String"))
+        } else {
+            XCTFail("variable type should be Array")
+        }
+    }
+
+    func test_array_asTypeAlias_willReturnExpectedTypes() throws {
+        let source = """
+        typealias ArrayShorthand = [(name: String, age: Int?)]?
+        typealias ArrayIdentifier = Array<String>
+        """
+        instanceUnderTest.updateToSource(source)
+        XCTAssertTrue(instanceUnderTest.isStale)
+        instanceUnderTest.collectChildren()
+        XCTAssertFalse(instanceUnderTest.isStale)
+        XCTAssertEqual(instanceUnderTest.typealiases.count, 2)
+
+        // typealias ArrayShorthand = [(name: String, age: Int?)]?
+        var target = instanceUnderTest.typealiases[0]
+        XCTAssertEqual(target.keyword, "typealias")
+        XCTAssertEqual(target.name, "ArrayShorthand")
+
+        if case let EntityType.array(array) = target.initializedType {
+            XCTAssertEqual(array.declType, .shorthand)
+            XCTAssertTrue(array.isOptional)
+            if case let EntityType.tuple(tuple) = array.elementType {
+                XCTAssertEqual(tuple.elements.count, 2)
+                XCTAssertEqual(tuple.elements[0].name, "name")
+                XCTAssertEqual(tuple.elements[0].type, .simple("String"))
+                XCTAssertEqual(tuple.elements[1].name, "age")
+                XCTAssertEqual(tuple.elements[1].type, .simple("Int?"))
+                XCTAssertFalse(tuple.isOptional)
+            }
+        } else {
+            XCTFail("variable type should be Array")
+        }
+
+        // typealias ArrayIdentifier = Array<String>)
+        target = instanceUnderTest.typealiases[1]
+        XCTAssertEqual(target.keyword, "typealias")
+        XCTAssertEqual(target.name, "ArrayIdentifier")
+
+        if case let EntityType.array(array) = target.initializedType {
+            XCTAssertEqual(array.declType, .keyword)
+            XCTAssertFalse(array.isOptional)
+            XCTAssertEqual(array.elementType, .simple("String"))
+        } else {
+            XCTFail("variable type should be Array")
+        }
+    }
+
+    // MARK: - Tests: Set
+
+    func test_set_inFunctionParameter_willReturnExpectedTypes() throws {
+        let source = """
+        func setIdentifier(names: Set<(name: String, age: Int?)>) {}
+        """
+        instanceUnderTest.updateToSource(source)
+        XCTAssertTrue(instanceUnderTest.isStale)
+        instanceUnderTest.collectChildren()
+        XCTAssertFalse(instanceUnderTest.isStale)
+        XCTAssertEqual(instanceUnderTest.functions.count, 1)
+
+        // func setIdentifier(names: Set<(name: String, age: Int?)>) {}
+        let function = instanceUnderTest.functions[0]
+        XCTAssertEqual(function.keyword, "func")
+        XCTAssertEqual(function.identifier, "setIdentifier")
+        XCTAssertNil(function.signature.effectSpecifiers?.throwsSpecifier)
+        XCTAssertNil(function.signature.effectSpecifiers?.asyncSpecifier)
+        XCTAssertEqual(function.signature.input.count, 1)
+
+        if case let EntityType.set(set) = function.signature.input[0].type {
+            XCTAssertFalse(set.isOptional)
+            if case let EntityType.tuple(tuple) = set.elementType {
+                XCTAssertEqual(tuple.elements.count, 2)
+                XCTAssertEqual(tuple.elements[0].name, "name")
+                XCTAssertEqual(tuple.elements[0].type, .simple("String"))
+                XCTAssertEqual(tuple.elements[1].name, "age")
+                XCTAssertEqual(tuple.elements[1].type, .simple("Int?"))
+                XCTAssertFalse(tuple.isOptional)
+            }
+        } else {
+            XCTFail("variable type should be Array")
+        }
+    }
+
+    func test_set_asVariable_willReturnExpectedTypes() throws {
+        let source = """
+        var setIdentifier: Set<(name: String, age: Int?)>
+        """
+        instanceUnderTest.updateToSource(source)
+        XCTAssertTrue(instanceUnderTest.isStale)
+        instanceUnderTest.collectChildren()
+        XCTAssertFalse(instanceUnderTest.isStale)
+        XCTAssertEqual(instanceUnderTest.variables.count, 1)
+
+        // var setIdentifier: Array<(name: String, age: Int?)>
+        let target = instanceUnderTest.variables[0]
+        XCTAssertEqual(target.keyword, "var")
+        XCTAssertEqual(target.name, "setIdentifier")
+
+        if case let EntityType.set(set) = target.type {
+            XCTAssertFalse(set.isOptional)
+            if case let EntityType.tuple(tuple) = set.elementType {
+                XCTAssertEqual(tuple.elements.count, 2)
+                XCTAssertEqual(tuple.elements[0].name, "name")
+                XCTAssertEqual(tuple.elements[0].type, .simple("String"))
+                XCTAssertEqual(tuple.elements[1].name, "age")
+                XCTAssertEqual(tuple.elements[1].type, .simple("Int?"))
+                XCTAssertFalse(tuple.isOptional)
+            }
+        } else {
+            XCTFail("variable type should be Set")
+        }
+    }
+
+    func test_set_asTypeAlias_willReturnExpectedTypes() throws {
+        let source = """
+        typealias SetIdentifier = Set<String>
+        """
+        instanceUnderTest.updateToSource(source)
+        XCTAssertTrue(instanceUnderTest.isStale)
+        instanceUnderTest.collectChildren()
+        XCTAssertFalse(instanceUnderTest.isStale)
+        XCTAssertEqual(instanceUnderTest.typealiases.count, 1)
+
+        // typealias SetIdentifier = Set<String>
+        let target = instanceUnderTest.typealiases[0]
+        XCTAssertEqual(target.keyword, "typealias")
+        XCTAssertEqual(target.name, "SetIdentifier")
+
+        if case let EntityType.set(set) = target.initializedType {
+            XCTAssertFalse(set.isOptional)
+            XCTAssertEqual(set.elementType, .simple("String"))
+        } else {
+            XCTFail("variable type should be Array")
+        }
+    }
+
+    // MARK: - Tests: Dictionary
+
+    func test_dictionary_inFunctionParameter_willReturnExpectedTypes() throws {
+        let source = """
+        func dictShorthand(persons: [String: (name: String, age: Int?)]?) {}
+        func dictIdentifier(names: Dictionary<String, (name: String, age: Int?)>) {}
+        """
+        instanceUnderTest.updateToSource(source)
+        XCTAssertTrue(instanceUnderTest.isStale)
+        instanceUnderTest.collectChildren()
+        XCTAssertFalse(instanceUnderTest.isStale)
+        XCTAssertEqual(instanceUnderTest.functions.count, 2)
+
+        // func dictShorthand(persons: [String: (name: String, age: Int?)]?) {}
+
+        var function = instanceUnderTest.functions[0]
+        XCTAssertEqual(function.keyword, "func")
+        XCTAssertEqual(function.identifier, "dictShorthand")
+        XCTAssertNil(function.signature.effectSpecifiers?.throwsSpecifier)
+        XCTAssertNil(function.signature.effectSpecifiers?.asyncSpecifier)
+        XCTAssertEqual(function.signature.input.count, 1)
+
+        if case let EntityType.dictionary(dict) = function.signature.input[0].type {
+            XCTAssertEqual(dict.declType, .shorthand)
+            XCTAssertTrue(dict.isOptional)
+            XCTAssertEqual(dict.keyType, .simple("String"))
+            if case let EntityType.tuple(tuple) = dict.valueType {
+                XCTAssertEqual(tuple.elements.count, 2)
+                XCTAssertEqual(tuple.elements[0].name, "name")
+                XCTAssertEqual(tuple.elements[0].type, .simple("String"))
+                XCTAssertEqual(tuple.elements[1].name, "age")
+                XCTAssertEqual(tuple.elements[1].type, .simple("Int?"))
+                XCTAssertFalse(tuple.isOptional)
+            }
+        } else {
+            XCTFail("function.signature.input[0] type should be Dictionary")
+        }
+
+        // func dictIdentifier(names: Dictionary<String, (name: String, age: Int?)>) {}
+        function = instanceUnderTest.functions[1]
+        XCTAssertEqual(function.keyword, "func")
+        XCTAssertEqual(function.identifier, "dictIdentifier")
+        XCTAssertNil(function.signature.effectSpecifiers?.throwsSpecifier)
+        XCTAssertNil(function.signature.effectSpecifiers?.asyncSpecifier)
+        XCTAssertEqual(function.signature.input.count, 1)
+
+        if case let EntityType.dictionary(dict) = function.signature.input[0].type {
+            XCTAssertEqual(dict.declType, .keyword)
+            XCTAssertFalse(dict.isOptional)
+            XCTAssertEqual(dict.keyType, .simple("String"))
+            if case let EntityType.tuple(tuple) = dict.valueType {
+                XCTAssertEqual(tuple.elements.count, 2)
+                XCTAssertEqual(tuple.elements[0].name, "name")
+                XCTAssertEqual(tuple.elements[0].type, .simple("String"))
+                XCTAssertEqual(tuple.elements[1].name, "age")
+                XCTAssertEqual(tuple.elements[1].type, .simple("Int?"))
+                XCTAssertFalse(tuple.isOptional)
+            }
+        } else {
+            XCTFail("function.signature.input[0] type should be Dictionary")
+        }
+    }
+
+    func test_dictionary_asVariable_willReturnExpectedTypes() throws {
+        let source = """
+        var dictShorthand: [String: (name: String, age: Int?)]?
+        var dictIdentifier: Dictionary<String, (name: String, age: Int?)>)
+        """
+        instanceUnderTest.updateToSource(source)
+        XCTAssertTrue(instanceUnderTest.isStale)
+        instanceUnderTest.collectChildren()
+        XCTAssertFalse(instanceUnderTest.isStale)
+        XCTAssertEqual(instanceUnderTest.variables.count, 2)
+
+        // var dictShorthand: [String: (name: String, age: Int?)]?
+        var target = instanceUnderTest.variables[0]
+        XCTAssertEqual(target.keyword, "var")
+        XCTAssertEqual(target.name, "dictShorthand")
+        XCTAssertTrue(target.isOptional)
+
+        if case let EntityType.dictionary(dict) = target.type {
+            XCTAssertEqual(dict.declType, .shorthand)
+            XCTAssertTrue(dict.isOptional)
+            XCTAssertEqual(dict.keyType, .simple("String"))
+            if case let EntityType.tuple(tuple) = dict.valueType {
+                XCTAssertEqual(tuple.elements.count, 2)
+                XCTAssertEqual(tuple.elements[0].name, "name")
+                XCTAssertEqual(tuple.elements[0].type, .simple("String"))
+                XCTAssertEqual(tuple.elements[1].name, "age")
+                XCTAssertEqual(tuple.elements[1].type, .simple("Int?"))
+                XCTAssertFalse(tuple.isOptional)
+            }
+        } else {
+            XCTFail("variable type should be Dictionary")
+        }
+
+        // var dictIdentifier: Dictionary<String, (name: String, age: Int?)>)
+        target = instanceUnderTest.variables[1]
+        XCTAssertEqual(target.keyword, "var")
+        XCTAssertEqual(target.name, "dictIdentifier")
+        XCTAssertFalse(target.isOptional)
+
+        if case let EntityType.dictionary(dict) = target.type {
+            XCTAssertEqual(dict.declType, .keyword)
+            XCTAssertFalse(dict.isOptional)
+            XCTAssertEqual(dict.keyType, .simple("String"))
+            if case let EntityType.tuple(tuple) = dict.valueType {
+                XCTAssertEqual(tuple.elements.count, 2)
+                XCTAssertEqual(tuple.elements[0].name, "name")
+                XCTAssertEqual(tuple.elements[0].type, .simple("String"))
+                XCTAssertEqual(tuple.elements[1].name, "age")
+                XCTAssertEqual(tuple.elements[1].type, .simple("Int?"))
+                XCTAssertFalse(tuple.isOptional)
+            }
+        } else {
+            XCTFail("variable type should be Array")
+        }
+    }
+
+    func test_dictionary_asTypeAlias_willReturnExpectedTypes() throws {
+        let source = """
+        typealias DictShorthand = [String: (name: String, age: Int?)]?
+        typealias DictIdentifier = Dictionary<String, (name: String, age: Int?)>
+        """
+        instanceUnderTest.updateToSource(source)
+        XCTAssertTrue(instanceUnderTest.isStale)
+        instanceUnderTest.collectChildren()
+        XCTAssertFalse(instanceUnderTest.isStale)
+        XCTAssertEqual(instanceUnderTest.typealiases.count, 2)
+
+        // typealias DictShorthand = [String: (name: String, age: Int?)]?
+        var target = instanceUnderTest.typealiases[0]
+        XCTAssertEqual(target.keyword, "typealias")
+        XCTAssertEqual(target.name, "DictShorthand")
+
+        if case let EntityType.dictionary(dict) = target.initializedType {
+            XCTAssertEqual(dict.declType, .shorthand)
+            XCTAssertTrue(dict.isOptional)
+            XCTAssertEqual(dict.keyType, .simple("String"))
+            if case let EntityType.tuple(tuple) = dict.valueType {
+                XCTAssertEqual(tuple.elements.count, 2)
+                XCTAssertEqual(tuple.elements[0].name, "name")
+                XCTAssertEqual(tuple.elements[0].type, .simple("String"))
+                XCTAssertEqual(tuple.elements[1].name, "age")
+                XCTAssertEqual(tuple.elements[1].type, .simple("Int?"))
+                XCTAssertFalse(tuple.isOptional)
+            }
+        } else {
+            XCTFail("variable type should be Dictionary")
+        }
+
+        // typealias DictIdentifier = Dictionary<String, (name: String, age: Int?)>
+        target = instanceUnderTest.typealiases[1]
+        XCTAssertEqual(target.keyword, "typealias")
+        XCTAssertEqual(target.name, "DictIdentifier")
+
+        if case let EntityType.dictionary(dict) = target.initializedType {
+            XCTAssertEqual(dict.declType, .keyword)
+            XCTAssertFalse(dict.isOptional)
+            XCTAssertEqual(dict.keyType, .simple("String"))
+            if case let EntityType.tuple(tuple) = dict.valueType {
+                XCTAssertEqual(tuple.elements.count, 2)
+                XCTAssertEqual(tuple.elements[0].name, "name")
+                XCTAssertEqual(tuple.elements[0].type, .simple("String"))
+                XCTAssertEqual(tuple.elements[1].name, "age")
+                XCTAssertEqual(tuple.elements[1].type, .simple("Int?"))
+                XCTAssertFalse(tuple.isOptional)
+            }
+        } else {
+            XCTFail("variable type should be Array")
+        }
+    }
 }

--- a/Tests/SyntaxSparrowTests/Supporting Types/EntityTypeTests.swift
+++ b/Tests/SyntaxSparrowTests/Supporting Types/EntityTypeTests.swift
@@ -44,7 +44,7 @@ final class EntityTypeTests: XCTestCase {
         XCTAssertEqual(function.signature.input.count, 1)
 
         if case let EntityType.array(array) = function.signature.input[0].type {
-            XCTAssertEqual(array.declType, .shorthand)
+            XCTAssertEqual(array.declType, .squareBrackets)
             XCTAssertTrue(array.isOptional)
             if case let EntityType.tuple(tuple) = array.elementType {
                 XCTAssertEqual(tuple.elements.count, 2)
@@ -67,7 +67,7 @@ final class EntityTypeTests: XCTestCase {
         XCTAssertEqual(function.signature.input.count, 1)
 
         if case let EntityType.array(array) = function.signature.input[0].type {
-            XCTAssertEqual(array.declType, .keyword)
+            XCTAssertEqual(array.declType, .generic)
             XCTAssertFalse(array.isOptional)
             XCTAssertEqual(array.elementType, .simple("String"))
         } else {
@@ -93,7 +93,7 @@ final class EntityTypeTests: XCTestCase {
         XCTAssertTrue(target.isOptional)
 
         if case let EntityType.array(array) = target.type {
-            XCTAssertEqual(array.declType, .shorthand)
+            XCTAssertEqual(array.declType, .squareBrackets)
             XCTAssertTrue(array.isOptional)
             if case let EntityType.tuple(tuple) = array.elementType {
                 XCTAssertEqual(tuple.elements.count, 2)
@@ -114,7 +114,7 @@ final class EntityTypeTests: XCTestCase {
         XCTAssertFalse(target.isOptional)
 
         if case let EntityType.array(array) = target.type {
-            XCTAssertEqual(array.declType, .keyword)
+            XCTAssertEqual(array.declType, .generic)
             XCTAssertFalse(array.isOptional)
             XCTAssertEqual(array.elementType, .simple("String"))
         } else {
@@ -139,7 +139,7 @@ final class EntityTypeTests: XCTestCase {
         XCTAssertEqual(target.name, "ArrayShorthand")
 
         if case let EntityType.array(array) = target.initializedType {
-            XCTAssertEqual(array.declType, .shorthand)
+            XCTAssertEqual(array.declType, .squareBrackets)
             XCTAssertTrue(array.isOptional)
             if case let EntityType.tuple(tuple) = array.elementType {
                 XCTAssertEqual(tuple.elements.count, 2)
@@ -159,7 +159,7 @@ final class EntityTypeTests: XCTestCase {
         XCTAssertEqual(target.name, "ArrayIdentifier")
 
         if case let EntityType.array(array) = target.initializedType {
-            XCTAssertEqual(array.declType, .keyword)
+            XCTAssertEqual(array.declType, .generic)
             XCTAssertFalse(array.isOptional)
             XCTAssertEqual(array.elementType, .simple("String"))
         } else {
@@ -278,7 +278,7 @@ final class EntityTypeTests: XCTestCase {
         XCTAssertEqual(function.signature.input.count, 1)
 
         if case let EntityType.dictionary(dict) = function.signature.input[0].type {
-            XCTAssertEqual(dict.declType, .shorthand)
+            XCTAssertEqual(dict.declType, .squareBrackets)
             XCTAssertTrue(dict.isOptional)
             XCTAssertEqual(dict.keyType, .simple("String"))
             if case let EntityType.tuple(tuple) = dict.valueType {
@@ -302,7 +302,7 @@ final class EntityTypeTests: XCTestCase {
         XCTAssertEqual(function.signature.input.count, 1)
 
         if case let EntityType.dictionary(dict) = function.signature.input[0].type {
-            XCTAssertEqual(dict.declType, .keyword)
+            XCTAssertEqual(dict.declType, .generics)
             XCTAssertFalse(dict.isOptional)
             XCTAssertEqual(dict.keyType, .simple("String"))
             if case let EntityType.tuple(tuple) = dict.valueType {
@@ -336,7 +336,7 @@ final class EntityTypeTests: XCTestCase {
         XCTAssertTrue(target.isOptional)
 
         if case let EntityType.dictionary(dict) = target.type {
-            XCTAssertEqual(dict.declType, .shorthand)
+            XCTAssertEqual(dict.declType, .squareBrackets)
             XCTAssertTrue(dict.isOptional)
             XCTAssertEqual(dict.keyType, .simple("String"))
             if case let EntityType.tuple(tuple) = dict.valueType {
@@ -358,7 +358,7 @@ final class EntityTypeTests: XCTestCase {
         XCTAssertFalse(target.isOptional)
 
         if case let EntityType.dictionary(dict) = target.type {
-            XCTAssertEqual(dict.declType, .keyword)
+            XCTAssertEqual(dict.declType, .generics)
             XCTAssertFalse(dict.isOptional)
             XCTAssertEqual(dict.keyType, .simple("String"))
             if case let EntityType.tuple(tuple) = dict.valueType {
@@ -391,7 +391,7 @@ final class EntityTypeTests: XCTestCase {
         XCTAssertEqual(target.name, "DictShorthand")
 
         if case let EntityType.dictionary(dict) = target.initializedType {
-            XCTAssertEqual(dict.declType, .shorthand)
+            XCTAssertEqual(dict.declType, .squareBrackets)
             XCTAssertTrue(dict.isOptional)
             XCTAssertEqual(dict.keyType, .simple("String"))
             if case let EntityType.tuple(tuple) = dict.valueType {
@@ -412,7 +412,7 @@ final class EntityTypeTests: XCTestCase {
         XCTAssertEqual(target.name, "DictIdentifier")
 
         if case let EntityType.dictionary(dict) = target.initializedType {
-            XCTAssertEqual(dict.declType, .keyword)
+            XCTAssertEqual(dict.declType, .generics)
             XCTAssertFalse(dict.isOptional)
             XCTAssertEqual(dict.keyType, .simple("String"))
             if case let EntityType.tuple(tuple) = dict.valueType {


### PR DESCRIPTION
- Adds the `.array`, `.set`, and `.dictionary` entity type cases
- Adds the `ArrayDecl`, `SetDecl`, and `DictionaryDecl` constituent types
- Added unit tests for new types and parsing