### PR TITLE
Add iOS platform version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,6 +7,7 @@ let package = Package(
     name: "SyntaxSparrow",
     platforms: [
         .macOS(.v10_15),
+        .iOS(.v13)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.


### PR DESCRIPTION
We use SyntaxSparrow for creating protocol mocks with macros. This protocols are needed for our swiftUI Previews for iOS.

If the platform version for iOS is missing, we will get the following error message:
"The package product 'SwiftSyntax' requires minimum platform version 13.0 for the iOS platform, but this target supports 12.0."

