### PR TITLE
Adding manual iOS tests

### DIFF
--- a/.github/workflows/unit-tests-ios.yml
+++ b/.github/workflows/unit-tests-ios.yml
@@ -1,0 +1,32 @@
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# GitHub recommends pinning actions to a commit SHA.
+# To get a newer version, you will need to update the SHA.
+# You can also reference a tag or branch, but the action may change without warning.
+
+name: iOS Unit Tests
+
+on: workflow_dispatch
+
+jobs:
+  build:
+    name: Xcode ${{ matrix.xcode }}
+    strategy:
+      matrix:
+        xcode: ["14.0", "14.3.1", "latest-stable"]
+    runs-on: macos-latest
+    steps:
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ matrix.xcode }}
+      - uses: actions/checkout@v3
+
+      - name: Build
+        run: xcodebuild build -scheme SyntaxSparrow -configuration Debug -destination "platform=iOS"
+
+      - name: Test
+        run: xcodebuild test-without-building -scheme SyntaxSparrow -configuration Debug -destination "platform=iOS" -enableCodeCoverage YES

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,7 +15,6 @@ on:
     branches:
       - main
       - develop
-      - 'release/**'
     push:
       branches:
         - main


### PR DESCRIPTION
Setting up for manually triggering iOS support tests until it can be folded into the automated PR flow.