### PR TITLE
[BUG] Fixing incorrect resolving of inout on parameters

### DIFF
--- a/Sources/SyntaxSparrow/Internal/Resolvers/Syntax/EnumCaseParameterSemanticsResolver.swift
+++ b/Sources/SyntaxSparrow/Internal/Resolvers/Syntax/EnumCaseParameterSemanticsResolver.swift
@@ -74,9 +74,8 @@ struct EnumCaseParameterSemanticsResolver: ParameterNodeSemanticsResolving {
     }
 
     func resolveIsInOut() -> Bool {
-        node.type.tokens(viewMode: .fixedUp).contains(where: {
-            $0.tokenKind == TokenKind.keyword(.inout)
-        })
+        let tokens = node.type.children(viewMode: .fixedUp).compactMap { $0.as(TokenSyntax.self) }
+        return tokens.contains(where: { $0.tokenKind == TokenKind.keyword(.inout) })
     }
 
     func resolveDescription() -> String {

--- a/Sources/SyntaxSparrow/Internal/Resolvers/Syntax/FunctionParameterSemanticsResolver.swift
+++ b/Sources/SyntaxSparrow/Internal/Resolvers/Syntax/FunctionParameterSemanticsResolver.swift
@@ -67,8 +67,7 @@ struct FunctionParameterSemanticsResolver: ParameterNodeSemanticsResolving {
     }
 
     func resolveIsInOut() -> Bool {
-        node.type.tokens(viewMode: .fixedUp).contains(where: {
-            $0.tokenKind == TokenKind.keyword(.inout)
-        })
+        let tokens = node.type.children(viewMode: .fixedUp).compactMap { $0.as(TokenSyntax.self) }
+        return tokens.contains(where: { $0.tokenKind == TokenKind.keyword(.inout) })
     }
 }

--- a/Sources/SyntaxSparrow/Internal/Resolvers/Syntax/TupleParameterSemanticsResolver.swift
+++ b/Sources/SyntaxSparrow/Internal/Resolvers/Syntax/TupleParameterSemanticsResolver.swift
@@ -68,6 +68,13 @@ struct TupleParameterSemanticsResolver: ParameterNodeSemanticsResolving {
     }
 
     func resolveIsInOut() -> Bool {
-        node.inoutKeyword != nil
+        guard node.inoutKeyword == nil else {
+            return true
+        }
+        guard let attributedType = node.children(viewMode: .fixedUp).first?.as(AttributedTypeSyntax.self) else {
+            return false
+        }
+        let tokens = attributedType.children(viewMode: .fixedUp).compactMap { $0.as(TokenSyntax.self) }
+        return tokens.contains(where: { $0.tokenKind == TokenKind.keyword(.inout) })
     }
 }

--- a/Tests/SyntaxSparrowTests/Declarations/EnumerationTests.swift
+++ b/Tests/SyntaxSparrowTests/Declarations/EnumerationTests.swift
@@ -342,6 +342,7 @@ final class DeinitializerTests: XCTestCase {
             case resultOptional(processResult: Result<String, Error>?)
             case defaultValue(name: String = "name")
             case inoutValue(names: inout [String])
+            case inoutValues(names: inout [String], inout String)
         }
         """#
         instanceUnderTest.updateToSource(source)
@@ -349,7 +350,7 @@ final class DeinitializerTests: XCTestCase {
         instanceUnderTest.collectChildren()
         XCTAssertFalse(instanceUnderTest.isStale)
         XCTAssertEqual(instanceUnderTest.enumerations.count, 1)
-        XCTAssertEqual(instanceUnderTest.enumerations[0].cases.count, 18)
+        XCTAssertEqual(instanceUnderTest.enumerations[0].cases.count, 19)
         let enumeration = instanceUnderTest.enumerations[0]
 
         // No Parameters
@@ -783,5 +784,44 @@ final class DeinitializerTests: XCTestCase {
         } else {
             XCTFail("function.signature.input[0] type should be Array")
         }
+
+        // Optional Result parameter
+        // case inoutValues(names: inout [String], inout String)
+        enumCase = enumeration.cases[18]
+        XCTAssertEqual(enumCase.keyword, "case")
+        XCTAssertEqual(enumCase.name, "inoutValues")
+        XCTAssertEqual(enumCase.associatedValues.count, 2)
+        XCTAssertEqual(enumCase.associatedValues[0].attributes, [])
+        XCTAssertEqual(enumCase.associatedValues[0].modifiers, [])
+        XCTAssertEqual(enumCase.associatedValues[0].name, "names")
+        XCTAssertNil(enumCase.associatedValues[0].secondName)
+        XCTAssertFalse(enumCase.associatedValues[0].isLabelOmitted)
+        XCTAssertFalse(enumCase.associatedValues[0].isVariadic)
+        XCTAssertFalse(enumCase.associatedValues[0].isOptional)
+        XCTAssertTrue(enumCase.associatedValues[0].isInOut)
+        XCTAssertEqual(enumCase.associatedValues[0].rawType, "inout [String]")
+        XCTAssertNil(enumCase.associatedValues[0].defaultArgument)
+        XCTAssertEqual(enumCase.associatedValues[0].description, "names: inout [String]")
+
+        if case let EntityType.array(array) = enumCase.associatedValues[0].type {
+            XCTAssertEqual(array.declType, .squareBrackets)
+            XCTAssertFalse(array.isOptional)
+            XCTAssertEqual(array.elementType, .simple("String"))
+        } else {
+            XCTFail("function.signature.input[0] type should be Array")
+        }
+
+        XCTAssertEqual(enumCase.associatedValues[1].attributes, [])
+        XCTAssertEqual(enumCase.associatedValues[1].modifiers, [])
+        XCTAssertNil(enumCase.associatedValues[1].name)
+        XCTAssertNil(enumCase.associatedValues[1].secondName)
+        XCTAssertFalse(enumCase.associatedValues[1].isLabelOmitted)
+        XCTAssertFalse(enumCase.associatedValues[1].isVariadic)
+        XCTAssertFalse(enumCase.associatedValues[1].isOptional)
+        XCTAssertTrue(enumCase.associatedValues[1].isInOut)
+        XCTAssertEqual(enumCase.associatedValues[1].rawType, "String")
+        XCTAssertNil(enumCase.associatedValues[1].defaultArgument)
+        XCTAssertEqual(enumCase.associatedValues[1].description, "inout String")
+        XCTAssertEqual(enumCase.associatedValues[1].type, .simple("String"))
     }
 }


### PR DESCRIPTION
Fixes bug where a declaration such as:

```swift
func doSomething(_ handler: @escaping (inout String, Int) -> Void, name: inout String) { ... }
```

would return `true` for the `isInOut` property on the resolved `handler` parameter. This was because it was assessing all child tokens (which includes the closure input parameters), rather than the immediate children of the node. When searching the immediate children, the `inout` is resolved as a `TokenSyntax` whose `tokenKind` matches `TokenKind.keyword(.inout)`. This check is accurate and does not cause the bug.

Also effected were parameters within a `TupleTypeSyntax/Tuple` where if the type was resolved to an attributed type (the above closure input tuple syntax for example) the parameter node would not have the `inoutKeyword` assigned as the node is an `AttributedTypeSyntax` (which requires the same strategy as the above child search)