### PR TITLE
Merging develop for 4.0.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ Currently, SyntaxSparrow supports Swift Package Manager (SPM).
 To add SyntaxSparrow to your project, add the following line to your dependencies in your Package.swift file:
 
 ```swift
-.package(url: "https://github.com/CheekyGhost-Labs/SyntaxSparrow", from: "3.3.0")
+.package(url: "https://github.com/CheekyGhost-Labs/SyntaxSparrow", from: "4.0.0")
 ```
 
 Then, add SyntaxSparrow as a dependency for your target:

--- a/Sources/SyntaxSparrow/Internal/Extensions/EntityType+Parsing.swift
+++ b/Sources/SyntaxSparrow/Internal/Extensions/EntityType+Parsing.swift
@@ -18,7 +18,7 @@ extension EntityType {
         }
     }
 
-    static func parseType(_ typeSyntax: TypeSyntaxProtocol) -> EntityType {
+    static func parseType(_ typeSyntax: TypeSyntaxProtocol, forceTuple: Bool = false) -> EntityType {
         // Simple
         if let simpleType = typeSyntax.as(IdentifierTypeSyntax.self) {
             // Result
@@ -64,7 +64,7 @@ extension EntityType {
 
         // Tuple
         if let tupleTypeSyntax = typeSyntax.as(TupleTypeSyntax.self) {
-            if tupleTypeSyntax.elements.count == 1, let innerElement = tupleTypeSyntax.elements.first {
+            if tupleTypeSyntax.elements.count == 1, let innerElement = tupleTypeSyntax.elements.first, !forceTuple {
                 return parseType(innerElement.type)
             } else if tupleTypeSyntax.elements.isEmpty {
                 let isOptional = tupleTypeSyntax.resolveIsTypeOptional()
@@ -98,14 +98,14 @@ extension EntityType {
         return .empty
     }
 
-    static func parseElementList(_ syntax: TupleTypeElementListSyntax) -> EntityType {
+    static func parseElementList(_ syntax: TupleTypeElementListSyntax, forceTuple: Bool = false) -> EntityType {
         let tuple = Tuple(node: syntax)
         if getEmptyTuple(tuple) != nil {
             let isOptional = syntax.resolveIsSyntaxOptional()
             return voidType(withRawValue: "()", isOptional: isOptional)
         }
         // This is probably not needed?
-        if let resolvedSingleElement = getSingleTupleElement(tuple) {
+        if let resolvedSingleElement = getSingleTupleElement(tuple), !forceTuple {
             return resolvedSingleElement
         }
         return .tuple(tuple)

--- a/Sources/SyntaxSparrow/Internal/Resolvers/Syntax/ClosureSemanticsResolver.swift
+++ b/Sources/SyntaxSparrow/Internal/Resolvers/Syntax/ClosureSemanticsResolver.swift
@@ -33,7 +33,7 @@ struct ClosureSemanticsResolver: SemanticsResolving {
 
     func resolveInput() -> EntityType {
         guard !node.parameters.isEmpty else { return .void("()", false) }
-        return EntityType.parseElementList(node.parameters)
+        return EntityType.parseElementList(node.parameters, forceTuple: true)
     }
 
     func resolveOutput() -> EntityType {

--- a/Sources/SyntaxSparrow/Public/Semantics/Components/Closure.swift
+++ b/Sources/SyntaxSparrow/Public/Semantics/Components/Closure.swift
@@ -29,6 +29,19 @@ public struct Closure: DeclarationComponent {
     // MARK: - Properties
 
     /// Will return the closure input element from the input `typeAnnotation` for the closure.
+    /// **Note:** This will **always** resolve to ``EntityType/tuple`` with one or more parameters
+    /// or ``EntityType/tuple`` if there are no inputs. i.e
+    /// ```swift
+    /// - ((name: inout String, age: Int) -> Void
+    /// - (inout String, Int) -> Void
+    /// - (String) -> Void
+    /// - () -> Void
+    /// ```
+    /// will result in:
+    /// - ``EntityType/tuple`` with a single tuple element. The single tuple element will have the `name: inout String` and `age: Int` elements
+    /// - ``EntityType/tuple`` with two elements. The inout `String` and the `Int`
+    /// - ``EntityType/tuple`` with a single element. The `String`
+    /// - ``EntityType/void``.
     public var input: EntityType { resolver.resolveInput() }
 
     /// Will return the input string for the closure. Returns an empty string if no result is found.

--- a/Tests/SyntaxSparrowTests/Declarations/EnumerationTests.swift
+++ b/Tests/SyntaxSparrowTests/Declarations/EnumerationTests.swift
@@ -609,13 +609,24 @@ final class DeinitializerTests: XCTestCase {
         XCTAssertEqual(enumCase.associatedValues[0].description, "_ handler: (Int) -> Void")
 
         if case let EntityType.closure(closure) = enumCase.associatedValues[0].type {
-            XCTAssertEqual(closure.input, .simple("Int"))
-            XCTAssertFalse(closure.isVoidInput)
+            // Void Output
             XCTAssertEqual(closure.output, .void("Void", false))
             XCTAssertTrue(closure.isVoidOutput)
             XCTAssertFalse(closure.isOptional)
             XCTAssertFalse(closure.isEscaping)
             XCTAssertFalse(closure.isAutoEscaping)
+            // Tuple Input (Single Element)
+            XCTAssertFalse(closure.isVoidInput)
+            if case let EntityType.tuple(tuple) = closure.input {
+                XCTAssertEqual(tuple.elements.count, 1)
+                XCTAssertEqual(tuple.elements[0].type, .simple("Int"))
+                XCTAssertEqual(tuple.elements[0].rawType, "Int")
+                XCTAssertFalse(tuple.elements[0].isInOut)
+                XCTAssertFalse(tuple.elements[0].isOptional)
+                XCTAssertFalse(tuple.elements[0].isLabelOmitted)
+                XCTAssertNil(tuple.elements[0].name)
+                XCTAssertNil(tuple.elements[0].secondName)
+            }
         } else {
             XCTFail("function.signature.input[0] type should be closure")
         }
@@ -639,13 +650,23 @@ final class DeinitializerTests: XCTestCase {
         XCTAssertEqual(enumCase.associatedValues[0].description, "_ handler: ((Int) -> Void)?")
 
         if case let EntityType.closure(closure) = enumCase.associatedValues[0].type {
-            XCTAssertEqual(closure.input, .simple("Int"))
-            XCTAssertFalse(closure.isVoidInput)
             XCTAssertEqual(closure.output, .void("Void", false))
             XCTAssertTrue(closure.isVoidOutput)
             XCTAssertTrue(closure.isOptional)
             XCTAssertTrue(closure.isEscaping)
             XCTAssertTrue(closure.isAutoEscaping)
+            // Tuple Input (Single Element)
+            XCTAssertFalse(closure.isVoidInput)
+            if case let EntityType.tuple(tuple) = closure.input {
+                XCTAssertEqual(tuple.elements.count, 1)
+                XCTAssertEqual(tuple.elements[0].type, .simple("Int"))
+                XCTAssertEqual(tuple.elements[0].rawType, "Int")
+                XCTAssertFalse(tuple.elements[0].isInOut)
+                XCTAssertFalse(tuple.elements[0].isOptional)
+                XCTAssertFalse(tuple.elements[0].isLabelOmitted)
+                XCTAssertNil(tuple.elements[0].name)
+                XCTAssertNil(tuple.elements[0].secondName)
+            }
         } else {
             XCTFail("function.signature.input[0] type should be closure")
         }

--- a/Tests/SyntaxSparrowTests/Declarations/VariableTests.swift
+++ b/Tests/SyntaxSparrowTests/Declarations/VariableTests.swift
@@ -438,10 +438,20 @@ final class VariableTests: XCTestCase {
         XCTAssertTrue(variable.hasSetter)
         XCTAssertEqual(variable.description, "var handler: (String) -> Int? = { _ in }")
         if case let EntityType.closure(closure) = variable.type {
-            XCTAssertEqual(closure.input, .simple("String"))
             XCTAssertEqual(closure.output, .simple("Int?"))
             XCTAssertFalse(closure.isOptional)
             XCTAssertEqual(closure.description, "(String) -> Int?")
+            // Closure Input Tuple (Single Element)
+            if case let EntityType.tuple(tuple) = closure.input {
+                XCTAssertEqual(tuple.elements.count, 1)
+                XCTAssertEqual(tuple.elements[0].type, .simple("String"))
+                XCTAssertEqual(tuple.elements[0].rawType, "String")
+                XCTAssertFalse(tuple.elements[0].isInOut)
+                XCTAssertFalse(tuple.elements[0].isOptional)
+                XCTAssertNil(tuple.elements[0].name)
+                XCTAssertNil(tuple.elements[0].secondName)
+                XCTAssertFalse(tuple.elements[0].isLabelOmitted)
+            }
         } else {
             XCTFail("variable type should be closure")
         }
@@ -454,10 +464,20 @@ final class VariableTests: XCTestCase {
         XCTAssertTrue(variable.hasSetter)
         XCTAssertEqual(variable.description, "var handler: ((String) -> Int?)? = { _ in }")
         if case let EntityType.closure(closure) = variable.type {
-            XCTAssertEqual(closure.input, .simple("String"))
             XCTAssertEqual(closure.output, .simple("Int?"))
             XCTAssertTrue(closure.isOptional)
             XCTAssertEqual(closure.description, "((String) -> Int?)?")
+            // Closure Input Tuple (Single Element)
+            if case let EntityType.tuple(tuple) = closure.input {
+                XCTAssertEqual(tuple.elements.count, 1)
+                XCTAssertEqual(tuple.elements[0].type, .simple("String"))
+                XCTAssertEqual(tuple.elements[0].rawType, "String")
+                XCTAssertFalse(tuple.elements[0].isInOut)
+                XCTAssertFalse(tuple.elements[0].isOptional)
+                XCTAssertNil(tuple.elements[0].name)
+                XCTAssertNil(tuple.elements[0].secondName)
+                XCTAssertFalse(tuple.elements[0].isLabelOmitted)
+            }
         } else {
             XCTFail("variable type should be closure")
         }


### PR DESCRIPTION

### [CHANGE] Updating closure input to always be tuple or void (#45)

#### Details
Updates the `Closure.input` type to always be either `tuple` with one or more elements, or a `Void` when empty.

This is due to some confusion when working with closure inputs within function constructs. Because things like `inout` really can only exist on a parameter, resolving a single closure input to a type would not provide all the information required. While the `EntityType` could have support added for looking up its parent context and resolving things like inout, it felt like it did not belong there.

As this only popped up for the Closure context, it made more sense to assign the element `EntityType.tuple` when one or more elements are present, rather than extracting the element type from a single input closure. This will ensure that various parameter-based properties are available.

This will mark a major version change however as consumers may be working with the previous behaviour.