### PR TITLE
[CHORE] Switching from apple swift-syntax to swiftlang

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -12,10 +12,10 @@
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax.git",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "fa8f95c2d536d6620cc2f504ebe8a6167c9fc2dd",
-        "version" : "510.0.1"
+        "revision" : "303e5c5c36d6a558407d364878df131c3546fad8",
+        "version" : "510.0.2"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jpsim/Yams.git",
       "state" : {
-        "revision" : "0d9ee7ea8c4ebd4a489ad7a73d5c6cad55d6fed3",
-        "version" : "5.0.6"
+        "revision" : "3036ba9d69cf1fd04d433527bc339dc0dc75433d",
+        "version" : "5.1.3"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-syntax.git", from: "510.0.1"),
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "510.0.1"),
     ],
     targets: [
         .target(

--- a/Package@swift-5.7.swift
+++ b/Package@swift-5.7.swift
@@ -20,7 +20,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-syntax.git", from: "510.0.1"),
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "510.0.1"),
     ],
     targets: [
         .target(

--- a/Package@swift-5.8.swift
+++ b/Package@swift-5.8.swift
@@ -20,7 +20,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-syntax.git", from: "510.0.1"),
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "510.0.1"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
Resolves noted future swift 6 error in [raised issue](https://github.com/CheekyGhost-Labs/SyntaxSparrow/issues/50)