### PR TITLE
Feature: Updating new swift-syntax version to 600.0.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "2bc86522d115234d1f588efe2bcb4ce4be8f8b82",
-        "version" : "510.0.3"
+        "revision" : "0687f71944021d616d34d922343dcef086855920",
+        "version" : "600.0.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "510.0.1"),
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "600.0.1"),
     ],
     targets: [
         .target(

--- a/Package@swift-5.7.swift
+++ b/Package@swift-5.7.swift
@@ -20,7 +20,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "510.0.1"),
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "600.0.1"),
     ],
     targets: [
         .target(

--- a/Package@swift-5.8.swift
+++ b/Package@swift-5.8.swift
@@ -20,7 +20,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "510.0.1"),
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "600.0.1"),
     ],
     targets: [
         .target(

--- a/Sources/SyntaxSparrow/Internal/Resolvers/Declaration/InitializerSemanticsResolver.swift
+++ b/Sources/SyntaxSparrow/Internal/Resolvers/Declaration/InitializerSemanticsResolver.swift
@@ -56,7 +56,7 @@ struct InitializerSemanticsResolver: SemanticsResolving {
     }
 
     func resolveThrowsOrRethrowsKeyword() -> String? {
-        node.signature.effectSpecifiers?.throwsSpecifier?.text.trimmed
+        node.signature.effectSpecifiers?.throwsClause?.throwsSpecifier.text.trimmed
     }
 
     func resolveEffectSpecifiers() -> EffectSpecifiers? {

--- a/Sources/SyntaxSparrow/Public/Semantics/Components/EffectsSpecifiers.swift
+++ b/Sources/SyntaxSparrow/Public/Semantics/Components/EffectsSpecifiers.swift
@@ -40,21 +40,21 @@ public struct EffectSpecifiers: Hashable, Equatable, CustomStringConvertible {
     /// Creates a new ``SyntaxSparrow/EffectSpecifiers`` instance from an `AccessorEffectSpecifiersSyntax` node.
     public init(node: AccessorEffectSpecifiersSyntax) {
         self.node = node
-        throwsSpecifier = node.throwsSpecifier?.text.trimmed
+        throwsSpecifier = node.throwsClause?.throwsSpecifier.text.trimmed
         asyncSpecifier = node.asyncSpecifier?.text.trimmed
     }
 
     /// Creates a new ``SyntaxSparrow/EffectSpecifiers`` instance from an `TypeEffectSpecifiersSyntax` node.
     public init(node: TypeEffectSpecifiersSyntax) {
         self.node = node
-        throwsSpecifier = node.throwsSpecifier?.text.trimmed
+        throwsSpecifier = node.throwsClause?.throwsSpecifier.text.trimmed
         asyncSpecifier = node.asyncSpecifier?.text.trimmed
     }
 
     /// Creates a new ``SyntaxSparrow/EffectSpecifiers`` instance from an `FunctionEffectSpecifiersSyntax` node.
     public init(node: FunctionEffectSpecifiersSyntax) {
         self.node = node
-        throwsSpecifier = node.throwsSpecifier?.text.trimmed
+        throwsSpecifier = node.throwsClause?.throwsSpecifier.text.trimmed
         asyncSpecifier = node.asyncSpecifier?.text.trimmed
     }
 


### PR DESCRIPTION
Feature: Updating new swift-syntax version to 600.0.1

Our project relies on other packages which need the new swift-syntax version.
So an update for the new swift-syntax version would be really useful for us.

I updated the version and removed the deprecations which occurred after the update.