### PR TITLE
Minor Chores for 5.1.0 release

### DIFF
--- a/Sources/SyntaxSparrow/Public/Protocols/ModifierAssessing.swift
+++ b/Sources/SyntaxSparrow/Public/Protocols/ModifierAssessing.swift
@@ -117,6 +117,7 @@ extension ModifierAssessing {
 
 // MARK: - Conformance
 
+extension AssociatedType: ModifierAssessing {}
 extension Actor: ModifierAssessing {}
 extension Class: ModifierAssessing {}
 extension Enumeration: ModifierAssessing {}
@@ -126,7 +127,6 @@ extension ProtocolDecl: ModifierAssessing {}
 extension Structure: ModifierAssessing {}
 extension Subscript: ModifierAssessing {}
 extension Typealias: ModifierAssessing {}
-
 extension Variable: ModifierAssessing {
 
     /// Returns `true` when the `private` keyword is within the modifier collection with the `set` detail assigned.

--- a/Sources/SyntaxSparrow/Public/Utilities/SyntaxSourceDetails.swift
+++ b/Sources/SyntaxSparrow/Public/Utilities/SyntaxSourceDetails.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Struct representing the raw source for a supporting ``SyntaxSparrow/Declaration` conforming instance
-public struct SyntaxSourceDetails {
+public struct SyntaxSourceDetails: Equatable {
     /// The start and end bounds of the source.
     public let location: SyntaxSourceLocation
 


### PR DESCRIPTION
- [CHORE] Adding Equatable conformance to SyntaxSourceDetails
- [CHORE] Exposing conformance of AssociatedType to ModifierAssessing